### PR TITLE
Replace micromamba with Miniconda

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ export LS_PROJECT_ID="1"
 
 chmod +x scripts/*.sh
 
-scripts/00_bootstrap.sh          # install system deps, micromamba, uv
+scripts/00_bootstrap.sh          # install system deps, Miniconda, uv
 scripts/01_create_conda_env.sh   # separate R/reticulate env (optional)
 scripts/02_git_init.sh
 scripts/03_uv_sync.sh

--- a/scripts/01_create_conda_env.sh
+++ b/scripts/01_create_conda_env.sh
@@ -6,21 +6,18 @@ source "$SCRIPT_DIR/lib_common.sh"
 ENV_NAME="rbridge"
 ensure_in_path
 
-if ! command -v micromamba >/dev/null 2>&1; then
-  echo "micromamba not found. Run scripts/00_bootstrap.sh first." >&2
+if ! command -v conda >/dev/null 2>&1; then
+  echo "conda not found. Run scripts/00_bootstrap.sh first." >&2
   exit 1
 fi
 
-export MAMBA_ROOT_PREFIX="$HOME/micromamba"
-mkdir -p "$MAMBA_ROOT_PREFIX"
+source "$HOME/miniconda3/etc/profile.d/conda.sh"
 
-eval "$(micromamba shell hook --shell bash -p "$MAMBA_ROOT_PREFIX")"
-
-if micromamba env list | grep -q "^$ENV_NAME "; then
+if conda env list | grep -q "^$ENV_NAME "; then
   echo "[INFO] Env '$ENV_NAME' already exists."
   exit 0
 fi
 
-micromamba create -y -n "$ENV_NAME" -c conda-forge python=3.11 r-base r-reticulate
+conda create -y -n "$ENV_NAME" -c conda-forge python=3.11 r-base r-reticulate
 echo "[INFO] Env '$ENV_NAME' created."
-echo "To use it: micromamba activate $ENV_NAME"
+echo "To use it: conda activate $ENV_NAME"


### PR DESCRIPTION
## Summary
- install Miniconda instead of micromamba in bootstrap script
- use conda for creating the optional R environment
- update run script comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fa8d19c0c8333bc137c1fce5cfa61