### PR TITLE
Improve active learning diarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ pyinstaller-demo/
 ├── README.md
 └── .gitignore
 ```
-</details> 
+</details>
+
+### Active learning fine-tuning
+
+The `active-learn` command runs an uncertainty sampling loop and fine-tunes
+`syvai/speaker-diarization-3.1` as new segments are labeled. Example:
+
+```bash
+python -m src.__main__ active-learn --iterations 5 --query_k 3 \
+  --lr 3e-5 --batch_size 2 --ft_epochs 2
+```
+
 
 

--- a/scripts/src/__main__.py
+++ b/scripts/src/__main__.py
@@ -18,6 +18,9 @@ def main():
     al.add_argument("--iterations", type=int, default=3)
     al.add_argument("--query_k", type=int, default=5)
     al.add_argument("--output_dir", type=str, default="checkpoints/active_learning")
+    al.add_argument("--batch_size", type=int, default=2)
+    al.add_argument("--lr", type=float, default=1e-5)
+    al.add_argument("--ft_epochs", type=int, default=1, help="Fine-tune epochs per iteration")
 
     args = p.parse_args()
     if args.cmd == "finetune":
@@ -25,7 +28,8 @@ def main():
                      output_dir=args.output_dir, sample_hours=args.sample_hours)
     else:
         run_active_learning(iterations=args.iterations, query_k=args.query_k,
-                            output_dir=args.output_dir)
+                            output_dir=args.output_dir, batch_size=args.batch_size,
+                            lr=args.lr, fine_tune_epochs=args.ft_epochs)
 
 if __name__ == "__main__":
     main()

--- a/scripts/src/active_learning_diarization.py
+++ b/scripts/src/active_learning_diarization.py
@@ -1,6 +1,5 @@
 # ===================== src/active_learning_diarization.py =====================
 import os
-import random
 from label_studio_sdk import Client
 from transformers import AutoProcessor, AutoModelForAudioFrameClassification
 import torch
@@ -11,7 +10,7 @@ from metrics import diarization_metrics
 MODEL_ID = "syvai/speaker-diarization-3.1"
 
 
-def run_active_learning(iterations, query_k, output_dir):
+def run_active_learning(iterations, query_k, output_dir, batch_size=2, lr=1e-5, fine_tune_epochs=1):
     os.makedirs(output_dir, exist_ok=True)
     processor = AutoProcessor.from_pretrained(MODEL_ID)
     model = AutoModelForAudioFrameClassification.from_pretrained(MODEL_ID)
@@ -22,18 +21,16 @@ def run_active_learning(iterations, query_k, output_dir):
     for it in range(iterations):
         # Fine-tune on current labeled set if any
         if labeled:
-            train_batch = segments_to_frame_labels(labeled, processor)
-            loss = _one_step_update(model, train_batch)
+            loss = None
+            for _ in range(fine_tune_epochs):
+                for batch in _create_batches(labeled, batch_size, processor):
+                    loss = _one_step_update(model, batch, lr)
             print(f"[IT {it}] fine-tune loss={loss:.4f}, labeled={len(labeled)}")
 
         # Score pool with uncertainty
         scores = []
         for ex in pool:
-            inputs = processor(ex["audio"]["array"], sampling_rate=ex["audio"]["sampling_rate"], return_tensors="pt")
-            with torch.no_grad():
-                logits = model(**inputs).logits
-            prob = torch.softmax(logits, -1).max().item()
-            scores.append((1 - prob))  # uncertainty
+            scores.append(_uncertainty_score(model, processor, ex))
         # pick top-k uncertain
         idxs = sorted(range(len(pool)), key=lambda i: scores[i], reverse=True)[:query_k]
         to_label = [pool[i] for i in idxs]
@@ -58,11 +55,25 @@ def run_active_learning(iterations, query_k, output_dir):
     model.save_pretrained(output_dir)
 
 
-def _one_step_update(model, batch):
+def _one_step_update(model, batch, lr=1e-5):
     model.train()
-    optim = torch.optim.AdamW(model.parameters(), lr=1e-5)
+    optim = torch.optim.AdamW(model.parameters(), lr=lr)
     optim.zero_grad()
     out = model(**batch)
     out.loss.backward()
     optim.step()
     return out.loss.item()
+
+
+def _uncertainty_score(model, processor, example):
+    inputs = processor(example["audio"]["array"], sampling_rate=example["audio"]["sampling_rate"], return_tensors="pt")
+    with torch.no_grad():
+        logits = model(**inputs).logits.squeeze(0)
+    probs = torch.softmax(logits, dim=-1)
+    mean_conf = probs.max(dim=-1).values.mean().item()
+    return 1 - mean_conf
+
+
+def _create_batches(examples, batch_size, processor):
+    for i in range(0, len(examples), batch_size):
+        yield segments_to_frame_labels(examples[i:i + batch_size], processor)


### PR DESCRIPTION
## Summary
- support uncertainty sampling active learning with batching and lr options
- expose active learning finetuning options in CLI
- document active learning usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python scripts/src/__main__.py -h` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_6883e88cf53c8333a5c15ce48fbb7d63