### PR TITLE
Improve active learning diarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ pyinstaller-demo/
 ├── README.md
 └── .gitignore
 ```
-</details> 
+</details>
+
+### Active learning fine-tuning
+
+The `active-learn` command runs an uncertainty sampling loop and fine-tunes
+`syvai/speaker-diarization-3.1` as new segments are labeled. Example:
+
+```bash
+python -m src.__main__ active-learn --iterations 5 --query_k 3 \
+  --lr 3e-5 --batch_size 2 --ft_epochs 2 \
+  --ls_token YOUR_TOKEN --project_id 1
+```
+
+`--ls_token` and `--project_id` configure the Label Studio project used for
+human-in-the-loop annotation. If omitted, a simple CLI simulator is used.
+
 
 

--- a/scripts/src/__main__.py
+++ b/scripts/src/__main__.py
@@ -1,7 +1,5 @@
 # ===================== src/__main__.py =====================
 import argparse
-from finetune_diarization import run_finetune
-from active_learning_diarization import run_active_learning
 
 def main():
     p = argparse.ArgumentParser()
@@ -18,14 +16,38 @@ def main():
     al.add_argument("--iterations", type=int, default=3)
     al.add_argument("--query_k", type=int, default=5)
     al.add_argument("--output_dir", type=str, default="checkpoints/active_learning")
+    al.add_argument("--batch_size", type=int, default=2)
+    al.add_argument("--lr", type=float, default=1e-5)
+    al.add_argument("--ft_epochs", type=int, default=1, help="Fine-tune epochs per iteration")
+    al.add_argument("--ls_url", type=str, default="http://localhost:8080", help="Label Studio base URL")
+    al.add_argument("--ls_token", type=str, default=None, help="Label Studio API token")
+    al.add_argument("--project_id", type=int, default=None, help="Label Studio project ID")
 
     args = p.parse_args()
     if args.cmd == "finetune":
-        run_finetune(epochs=args.epochs, batch_size=args.batch_size, lr=args.lr,
-                     output_dir=args.output_dir, sample_hours=args.sample_hours)
+        from finetune_diarization import run_finetune
+
+        run_finetune(
+            epochs=args.epochs,
+            batch_size=args.batch_size,
+            lr=args.lr,
+            output_dir=args.output_dir,
+            sample_hours=args.sample_hours,
+        )
     else:
-        run_active_learning(iterations=args.iterations, query_k=args.query_k,
-                            output_dir=args.output_dir)
+        from active_learning_diarization import run_active_learning
+
+        run_active_learning(
+            iterations=args.iterations,
+            query_k=args.query_k,
+            output_dir=args.output_dir,
+            batch_size=args.batch_size,
+            lr=args.lr,
+            fine_tune_epochs=args.ft_epochs,
+            ls_url=args.ls_url,
+            ls_token=args.ls_token,
+            project_id=args.project_id,
+        )
 
 if __name__ == "__main__":
     main()

--- a/scripts/src/active_learning_diarization.py
+++ b/scripts/src/active_learning_diarization.py
@@ -1,20 +1,39 @@
 # ===================== src/active_learning_diarization.py =====================
 import os
-import random
 from label_studio_sdk import Client
 from transformers import AutoProcessor, AutoModelForAudioFrameClassification
 import torch
-from data_io import (download_unlabeled_pool, annotate_segments_interactive,
-                     segments_to_frame_labels)
+from data_io import (
+    download_unlabeled_pool,
+    annotate_segments_interactive,
+    segments_to_frame_labels,
+    annotate_segments_labelstudio,
+)
 from metrics import diarization_metrics
 
 MODEL_ID = "syvai/speaker-diarization-3.1"
 
 
-def run_active_learning(iterations, query_k, output_dir):
+def run_active_learning(
+    iterations,
+    query_k,
+    output_dir,
+    batch_size=2,
+    lr=1e-5,
+    fine_tune_epochs=1,
+    ls_url=None,
+    ls_token=None,
+    project_id=None,
+):
     os.makedirs(output_dir, exist_ok=True)
     processor = AutoProcessor.from_pretrained(MODEL_ID)
     model = AutoModelForAudioFrameClassification.from_pretrained(MODEL_ID)
+
+    client = None
+    project = None
+    if ls_token and project_id:
+        client = Client(url=ls_url, api_key=ls_token)
+        project = client.get_project(project_id)
 
     labeled = []  # list of dicts with audio + frame_labels
     pool = download_unlabeled_pool(limit=30)
@@ -22,24 +41,25 @@ def run_active_learning(iterations, query_k, output_dir):
     for it in range(iterations):
         # Fine-tune on current labeled set if any
         if labeled:
-            train_batch = segments_to_frame_labels(labeled, processor)
-            loss = _one_step_update(model, train_batch)
+            loss = None
+            for _ in range(fine_tune_epochs):
+                for batch in _create_batches(labeled, batch_size, processor):
+                    loss = _one_step_update(model, batch, lr)
             print(f"[IT {it}] fine-tune loss={loss:.4f}, labeled={len(labeled)}")
 
         # Score pool with uncertainty
         scores = []
         for ex in pool:
-            inputs = processor(ex["audio"]["array"], sampling_rate=ex["audio"]["sampling_rate"], return_tensors="pt")
-            with torch.no_grad():
-                logits = model(**inputs).logits
-            prob = torch.softmax(logits, -1).max().item()
-            scores.append((1 - prob))  # uncertainty
+            scores.append(_uncertainty_score(model, processor, ex))
         # pick top-k uncertain
         idxs = sorted(range(len(pool)), key=lambda i: scores[i], reverse=True)[:query_k]
         to_label = [pool[i] for i in idxs]
 
         # Send to Label Studio or simple CLI labeling
-        newly_labeled = annotate_segments_interactive(to_label)
+        if project:
+            newly_labeled = annotate_segments_labelstudio(to_label, project)
+        else:
+            newly_labeled = annotate_segments_interactive(to_label)
         labeled.extend(newly_labeled)
 
         # remove from pool
@@ -58,11 +78,25 @@ def run_active_learning(iterations, query_k, output_dir):
     model.save_pretrained(output_dir)
 
 
-def _one_step_update(model, batch):
+def _one_step_update(model, batch, lr=1e-5):
     model.train()
-    optim = torch.optim.AdamW(model.parameters(), lr=1e-5)
+    optim = torch.optim.AdamW(model.parameters(), lr=lr)
     optim.zero_grad()
     out = model(**batch)
     out.loss.backward()
     optim.step()
     return out.loss.item()
+
+
+def _uncertainty_score(model, processor, example):
+    inputs = processor(example["audio"]["array"], sampling_rate=example["audio"]["sampling_rate"], return_tensors="pt")
+    with torch.no_grad():
+        logits = model(**inputs).logits.squeeze(0)
+    probs = torch.softmax(logits, dim=-1)
+    mean_conf = probs.max(dim=-1).values.mean().item()
+    return 1 - mean_conf
+
+
+def _create_batches(examples, batch_size, processor):
+    for i in range(0, len(examples), batch_size):
+        yield segments_to_frame_labels(examples[i:i + batch_size], processor)

--- a/scripts/src/finetune_diarization.py
+++ b/scripts/src/finetune_diarization.py
@@ -1,7 +1,11 @@
 # ===================== src/finetune_diarization.py =====================
 import os
-from datasets import load_dataset, Audio
-from transformers import AutoProcessor, AutoModelForAudioFrameClassification, TrainingArguments, Trainer
+from transformers import (
+    AutoProcessor,
+    AutoModelForAudioFrameClassification,
+    TrainingArguments,
+    Trainer,
+)
 import torch
 from metrics import diarization_metrics
 from data_io import make_rttm_from_segments, segments_from_dataset
@@ -11,8 +15,9 @@ MODEL_ID = "syvai/speaker-diarization-3.1"
 
 def prepare_dataset(sample_hours=0.1):
     """Download a tiny public dataset with speaker labels (AMI small subset via HF)."""
-    ds = load_dataset("ami_iwslt/ami", "sdm", split="train[:2%]")  # tiny subset
-    # ensure audio column
+    from datasets import load_dataset, Audio
+
+    ds = load_dataset("ami_iwslt/ami", "sdm", split="train[:2%]")
     if "audio" not in ds.column_names:
         ds = ds.cast_column("audio", Audio())
     return ds


### PR DESCRIPTION
## Summary
- support Label Studio integration for active learning loop
- add CLI options for Label Studio connection
- lazy import heavy deps to allow help message without installed packages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python scripts/src/__main__.py -h`

------
https://chatgpt.com/codex/tasks/task_e_6883e88cf53c8333a5c15ce48fbb7d63