### PR TITLE
Add active learning demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ During each iteration the script fine-tunes `syvai/speaker-diarization-3.1`
 on all labeled segments using mini‑batch updates. Use `--batch_size`, `--lr`
 and `--ft_epochs` to control this process.
 `--model_id` can override the base model (defaults to `syvai/speaker-diarization-3.1`).
+### Running the active learning demo
+
+Execute `scripts/04_run_demos.sh` to run the uncertainty-sampling loop over a small audio pool and save the model checkpoint.
+

--- a/scripts/04_run_demos.sh
+++ b/scripts/04_run_demos.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib_common.sh"
+
+ensure_in_path
+
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Run the active learning demo using uncertainty sampling
+uv run python -m src.__main__ active-learn \
+  --iterations 2 \
+  --query_k 3 \
+  --output_dir "checkpoints/active_learning_demo"
+


### PR DESCRIPTION
## Summary
- add `scripts/04_run_demos.sh` to run the active-learning diarization example
- document how to launch the demo in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6884a16dfe488333bc4ec3c62664ed98