### PR TITLE
Handle headless mode in GUI

### DIFF
--- a/front/gui.py
+++ b/front/gui.py
@@ -462,7 +462,12 @@ class LabelStudioController:
 def run_gui():
     """Main entry point for the GUI application."""
     controller = LabelStudioController()
-    controller.run_gui()
+    try:
+        controller.run_gui()
+    except tk.TclError as exc:
+        # Gracefully handle environments without a display (e.g. CI/headless)
+        print(f"Tkinter GUI cannot be started: {exc}")
+        print("Running in headless mode – no GUI will be shown.")
 
 
 if __name__ == "__main__":

--- a/test/test_gui.py
+++ b/test/test_gui.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+import pytest
+
+# Ensure project root is on path for importing 'front'
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from front import gui
+
+def test_run_gui_headless(monkeypatch, capsys):
+    """Ensure run_gui handles TclError gracefully."""
+    def fake_Tk():
+        raise gui.tk.TclError("no display name and no $DISPLAY")
+    monkeypatch.setattr(gui.tk, "Tk", fake_Tk)
+    gui.run_gui()
+    captured = capsys.readouterr()
+    assert "Tkinter GUI cannot be started" in captured.out

--- a/test/test_llm_backend.py
+++ b/test/test_llm_backend.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+import os
+import types
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def dummy_pipeline(task, model):
+    assert task == "automatic-speech-recognition"
+    assert model == "openai/whisper-small"
+    return lambda path: {"text": f"transcribed {path}"}
+
+
+def prepare_model(monkeypatch):
+    model_module = types.SimpleNamespace(LabelStudioMLBase=object)
+    ls_module = types.ModuleType("label_studio_ml")
+    ls_module.model = model_module
+    monkeypatch.setitem(sys.modules, "label_studio_ml", ls_module)
+    monkeypatch.setitem(sys.modules, "label_studio_ml.model", model_module)
+    import back.llm_backend as backend
+    monkeypatch.setattr(backend, "pipeline", dummy_pipeline)
+    return backend.LLMInteractiveModel
+
+
+def test_predict_transcribes_audio(monkeypatch):
+    LLMInteractiveModel = prepare_model(monkeypatch)
+    model = LLMInteractiveModel()
+    tasks = [{"data": {"audio": "clip.wav"}}, {"data": {}}]
+    result = model.predict(tasks)
+    assert result == [
+        {
+            "result": [
+                {
+                    "from_name": "transcription",
+                    "to_name": "audio",
+                    "type": "textarea",
+                    "value": {"text": ["transcribed clip.wav"]},
+                }
+            ]
+        }
+    ]
+
+
+def test_fit_returns_empty_dict(monkeypatch):
+    LLMInteractiveModel = prepare_model(monkeypatch)
+    model = LLMInteractiveModel()
+    assert model.fit([], None) == {}
+
+
+def test_hf_token_sets_env(monkeypatch):
+    LLMInteractiveModel = prepare_model(monkeypatch)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    LLMInteractiveModel(hf_token="xyz")
+    assert os.environ["HF_TOKEN"] == "xyz"

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import types
+import importlib
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_server_initialises_app(monkeypatch):
+    """Server should expose app created by init_app with configured model."""
+    sentinel_app = object()
+    def init_app(model):
+        init_app.model = model
+        return sentinel_app
+
+    # Create fake label_studio_ml package with api and model submodules
+    model_module = types.SimpleNamespace(LabelStudioMLBase=object)
+    ls_module = types.ModuleType("label_studio_ml")
+    ls_module.api = types.SimpleNamespace(init_app=init_app)
+    ls_module.model = model_module
+    monkeypatch.setitem(sys.modules, "label_studio_ml", ls_module)
+    monkeypatch.setitem(sys.modules, "label_studio_ml.api", ls_module.api)
+    monkeypatch.setitem(sys.modules, "label_studio_ml.model", model_module)
+
+    import back.llm_backend as backend
+
+    class DummyModel:
+        def __init__(self, hf_token=None, model_name="openai/whisper-small"):
+            self.hf_token = hf_token
+            self.model_name = model_name
+
+    monkeypatch.setattr(backend, "LLMInteractiveModel", DummyModel)
+    monkeypatch.setenv("HF_TOKEN", "abc123")
+
+    if "server" in sys.modules:
+        del sys.modules["server"]
+    server = importlib.import_module("server")
+
+    assert server.app is sentinel_app
+    assert isinstance(init_app.model, DummyModel)
+    assert init_app.model.hf_token == "abc123"
+    assert init_app.model.model_name == "openai/whisper-small"


### PR DESCRIPTION
## Summary
- Allow `front/gui.py` to run in environments without a display by catching `tk.TclError`
- Add unit test to ensure GUI startup handles headless environments gracefully
- Add unit tests for server initialization and the LLM backend's prediction and environment handling

## Testing
- `python front/gui.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adcb5685a883339c1d3295c9abae94