### PR TITLE
Link Label Studio frontend with ML backend

### DIFF
--- a/front/gui.py
+++ b/front/gui.py
@@ -53,8 +53,16 @@ def install_label_studio():
 
         # Start Label Studio after install
         try:
-            subprocess.Popen(["label-studio", "start"])
-            msg = 'label-studio successfully installed and started! Use browser and enter: http://localhost:8080/user/login/'
+            subprocess.Popen([
+                "label-studio",
+                "start",
+                "--ml-backend",
+                "http://localhost:9090",
+            ])
+            msg = (
+                "label-studio successfully installed and started with ML backend! "
+                "Use browser and enter: http://localhost:8080/user/login/"
+            )
         except Exception as e:
             msg = f"Installed, but failed to start: {e}"
 


### PR DESCRIPTION
## Summary
- start Label Studio with `--ml-backend http://localhost:9090` after installation

## Testing
- `python -m py_compile front/gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aec315317c8333932eff025953cc3a