### PR TITLE
Replace uvicorn with FastAPI CLI

### DIFF
--- a/front/gui.py
+++ b/front/gui.py
@@ -19,18 +19,18 @@ def start_server():
     if server_process is None:
         env = os.environ.copy()
         env["HF_TOKEN"] = os.getenv("HF_TOKEN", "")  # Read from environment or empty
-        # Start server in a background process using uvicorn directly
+        # Start server in a background process using the FastAPI CLI
         server_process = subprocess.Popen(
             [
                 sys.executable,
                 "-m",
-                "uvicorn",
+                "fastapi",
+                "dev",
                 "server:app",
                 "--host",
                 "0.0.0.0",
                 "--port",
                 "9090",
-                "--reload"
             ],
             env=env
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 fastapi[standard]
-uvicorn[standard]
 label-studio
 label-studio-ml
 transformers


### PR DESCRIPTION
## Summary
- start backend using FastAPI CLI instead of uvicorn
- drop explicit uvicorn dependency

## Testing
- `bash test/test.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aef2b9347c8333a6134d76fbdb29f6