### PR TITLE
Delay heavy imports until audio features are needed

### DIFF
--- a/audio_processing/preprocessing.py
+++ b/audio_processing/preprocessing.py
@@ -12,13 +12,9 @@ for both diarization (pyannote.audio) and transcription (NeMo ASR) pipelines.
 """
 
 import os
-import librosa
-import soundfile as sf
 from pathlib import Path
 from typing import Union, Optional
 import logging
-from pydub import AudioSegment
-import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -44,8 +40,33 @@ class AudioPreprocessor:
         # Create output directory for processed files
         self.output_dir = Path("processed_audio")
         self.output_dir.mkdir(exist_ok=True)
-        
+
+        # Flag to track lazy-loaded dependencies
+        self._deps_loaded = False
+
         logger.info(f"AudioPreprocessor initialized: {target_sample_rate}Hz, {target_channels} channels")
+
+    def _load_dependencies(self):
+        """Lazily load heavy audio processing dependencies."""
+        if self._deps_loaded:
+            return
+        try:
+            import librosa  # type: ignore
+            import soundfile as sf  # type: ignore
+            from pydub import AudioSegment  # type: ignore
+            import numpy as np  # type: ignore
+        except ImportError as e:
+            raise RuntimeError(
+                "Required audio processing packages are missing. "
+                "Please run 'Setup All Environments' to install dependencies."
+            ) from e
+
+        # Store references to loaded modules
+        self.librosa = librosa
+        self.sf = sf
+        self.AudioSegment = AudioSegment
+        self.np = np
+        self._deps_loaded = True
     
     def preprocess_mp3_to_mono_16k(self, input_path: Union[str, Path]) -> str:
         """
@@ -69,6 +90,13 @@ class AudioPreprocessor:
             ValueError: If input file is not a valid audio file
             RuntimeError: If preprocessing fails
         """
+        self._load_dependencies()
+
+        librosa = self.librosa
+        sf = self.sf
+        AudioSegment = self.AudioSegment
+        np = self.np
+
         input_path = Path(input_path)
         
         # Validate input file
@@ -106,7 +134,7 @@ class AudioPreprocessor:
             else:
                 # Method 2: Use librosa for other formats (more precise)
                 audio_data, original_sr = librosa.load(
-                    str(input_path), 
+                    str(input_path),
                     sr=self.target_sample_rate,  # Automatically resample
                     mono=True  # Convert to mono
                 )
@@ -143,6 +171,11 @@ class AudioPreprocessor:
             output_path (Path): Path to the processed audio file
         """
         try:
+            self._load_dependencies()
+            librosa = self.librosa
+            sf = self.sf
+            np = self.np
+
             # Load and validate the processed file
             audio_data, sample_rate = librosa.load(str(output_path), sr=None, mono=False)
             
@@ -189,9 +222,12 @@ class AudioPreprocessor:
             output_path (Path): Processed output file path
         """
         try:
+            self._load_dependencies()
+            librosa = self.librosa
+
             # Input file stats
             input_size = input_path.stat().st_size / (1024 * 1024)  # MB
-            
+
             # Output file stats
             output_size = output_path.stat().st_size / (1024 * 1024)  # MB
             output_data, output_sr = librosa.load(str(output_path), sr=None)
@@ -261,15 +297,19 @@ class AudioPreprocessor:
             dict: Dictionary containing audio file information
         """
         audio_path = Path(audio_path)
-        
+
         try:
+            self._load_dependencies()
+            librosa = self.librosa
+            np = self.np
+
             # Load audio metadata
             audio_data, sample_rate = librosa.load(str(audio_path), sr=None, mono=False)
-            
+
             # Calculate statistics
             duration = len(audio_data) / sample_rate if len(audio_data.shape) == 1 else len(audio_data[0]) / sample_rate
             file_size = audio_path.stat().st_size / (1024 * 1024)  # MB
-            
+
             # Handle stereo/mono
             if len(audio_data.shape) == 1:
                 channels = 1
@@ -279,7 +319,7 @@ class AudioPreprocessor:
                 channels = audio_data.shape[0]
                 rms_level = np.sqrt(np.mean(audio_data**2))
                 peak_level = np.max(np.abs(audio_data))
-            
+
             return {
                 'filename': audio_path.name,
                 'duration_seconds': round(duration, 2),
@@ -291,7 +331,7 @@ class AudioPreprocessor:
                 'format': audio_path.suffix.lower(),
                 'is_preprocessed': sample_rate == self.target_sample_rate and channels == 1
             }
-            
+
         except Exception as e:
             logger.error(f"Could not get audio info for {audio_path}: {e}")
             return {'error': str(e)}

--- a/audio_processing/utils.py
+++ b/audio_processing/utils.py
@@ -6,8 +6,6 @@ including format validation, file management, and audio analysis helpers.
 """
 
 import os
-import librosa
-import numpy as np
 from pathlib import Path
 from typing import Union, List, Dict, Tuple, Optional
 import logging
@@ -15,6 +13,22 @@ import json
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
+
+def _load_dependencies():
+    """Lazily import heavy optional dependencies."""
+    global librosa, np
+    if 'librosa' in globals() and 'np' in globals():
+        return
+    try:
+        import librosa  # type: ignore
+        import numpy as np  # type: ignore
+        globals()['librosa'] = librosa
+        globals()['np'] = np
+    except ImportError as e:
+        raise RuntimeError(
+            "Audio utilities require 'librosa' and 'numpy'. "
+            "Please run 'Setup All Environments' to install dependencies."
+        ) from e
 
 class AudioUtils:
     """
@@ -84,6 +98,7 @@ class AudioUtils:
             
             # Try to load the file
             try:
+                _load_dependencies()
                 audio_data, sr = librosa.load(str(path), sr=None, duration=1.0)  # Load only 1 second for testing
                 result['loadable'] = True
                 
@@ -118,6 +133,7 @@ class AudioUtils:
             Optional[float]: Duration in seconds, None if error
         """
         try:
+            _load_dependencies()
             duration = librosa.get_duration(path=str(file_path))
             return duration
         except Exception as e:
@@ -137,21 +153,23 @@ class AudioUtils:
             Dict[str, float]: Quality metrics
         """
         try:
+            _load_dependencies()
+
             # Basic statistics
             rms = np.sqrt(np.mean(audio_data**2))
             peak = np.max(np.abs(audio_data))
-            
+
             # Dynamic range
             db_range = 20 * np.log10(peak / (rms + 1e-10))
-            
+
             # Zero crossing rate (indicator of speech vs music)
             zcr = librosa.feature.zero_crossing_rate(audio_data)[0]
             avg_zcr = np.mean(zcr)
-            
+
             # Spectral centroid (brightness indicator)
             spectral_centroids = librosa.feature.spectral_centroid(y=audio_data, sr=sample_rate)[0]
             avg_centroid = np.mean(spectral_centroids)
-            
+
             # MFCC features (relevant for speech)
             mfccs = librosa.feature.mfcc(y=audio_data, sr=sample_rate, n_mfcc=13)
             mfcc_mean = np.mean(mfccs, axis=1)
@@ -200,12 +218,14 @@ class AudioUtils:
             
             # Load audio for quality analysis
             try:
+                _load_dependencies()
                 input_audio, input_sr = librosa.load(str(input_path), sr=None, duration=5.0)  # Analyze first 5 seconds
                 output_audio, output_sr = librosa.load(str(output_path), sr=None, duration=5.0)
-                
+
                 input_quality = AudioUtils.analyze_audio_quality(input_audio, input_sr)
                 output_quality = AudioUtils.analyze_audio_quality(output_audio, output_sr)
-            except:
+            except Exception as e:
+                logger.warning(f"Quality analysis skipped: {e}")
                 input_quality = {}
                 output_quality = {}
             

--- a/communication/server_manager.py
+++ b/communication/server_manager.py
@@ -17,8 +17,15 @@ import subprocess
 import signal
 import time
 import logging
-import psutil
-import requests
+try:
+    import psutil  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    psutil = None
+
+try:
+    import requests  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    requests = None
 from pathlib import Path
 from typing import Dict, List, Optional, Union, Tuple
 import threading
@@ -102,9 +109,15 @@ class ServerManager:
         self.venv_dir = Path(".venvs")
         self.diarization_venv = self.venv_dir / "diarization"
         self.transcription_venv = self.venv_dir / "transcription"
-        
+
         logger.info("ServerManager initialized")
-    
+        if psutil is None or requests is None:
+            missing = [name for name, mod in (('psutil', psutil), ('requests', requests)) if mod is None]
+            logger.warning(
+                "Missing optional packages: " + ", ".join(missing) +
+                ". Install them via 'Setup All Environments' for full functionality."
+            )
+
     def setup_virtual_environments(self):
         """
         Set up virtual environments for diarization and transcription.
@@ -117,18 +130,31 @@ class ServerManager:
         try:
             # Create .venvs directory
             self.venv_dir.mkdir(exist_ok=True)
-            
+
             # Setup diarization environment
             self._setup_diarization_environment()
-            
+
             # Setup transcription environment
             self._setup_transcription_environment()
-            
+
             logger.info("Virtual environments setup completed")
-            
+
         except Exception as e:
             logger.error(f"Virtual environment setup failed: {e}")
             raise RuntimeError(f"Cannot setup virtual environments: {e}")
+
+    def _ensure_runtime_dependencies(self):
+        """Ensure optional runtime dependencies are available."""
+        missing = []
+        if psutil is None:
+            missing.append("psutil")
+        if requests is None:
+            missing.append("requests")
+        if missing:
+            raise RuntimeError(
+                "Missing required packages: " + ", ".join(missing) +
+                ". Please run 'Setup All Environments' to install dependencies."
+            )
     
     def _get_uv_executable(self):
         """Get the path to uv executable, checking bundled location first."""
@@ -356,8 +382,9 @@ class ServerManager:
         if self.is_server_running(server_type):
             logger.warning(f"{server_type.value} server is already running")
             return True
-        
+
         try:
+            self._ensure_runtime_dependencies()
             config = self.configs[server_type]
             
             # Update server info

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -117,8 +117,12 @@ class AudioProcessingApp:
                                    command=self.preprocess_audio)
         preprocess_btn.grid(row=1, column=0, pady=(10, 0), sticky=tk.W)
         
-        self.preprocess_status_var = tk.StringVar(value="")\n        preprocess_status = ttk.Label(file_frame, textvariable=self.preprocess_status_var, 
-                                     foreground="green")
+        self.preprocess_status_var = tk.StringVar(value="")
+        preprocess_status = ttk.Label(
+            file_frame,
+            textvariable=self.preprocess_status_var,
+            foreground="green"
+        )
         preprocess_status.grid(row=1, column=1, columnspan=2, pady=(10, 0), sticky=tk.W, padx=(10, 0))
     
     def setup_pipeline_section(self, parent: ttk.Frame, row: int):


### PR DESCRIPTION
## Summary
- Lazily load audio-processing dependencies like librosa and pydub inside preprocessing and utility modules
- Make psutil and requests optional in server manager and verify they exist before starting servers
- Clean up GUI preprocessing status widget

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b848269c6c8333a4f5c8bfee1a6cec