### PR TITLE
Add server stop controls with automatic env setup

### DIFF
--- a/communication/server_manager.py
+++ b/communication/server_manager.py
@@ -465,7 +465,14 @@ class ServerManager:
             script = "server.py"
         
         python_path = venv / ("Scripts/python" if os.name == 'nt' else "bin/python")
-        
+
+        if not python_path.exists():
+            # Automatically set up the required environment using uv
+            if server_type == ServerType.DIARIZATION:
+                self._setup_diarization_environment()
+            else:
+                self._setup_transcription_environment()
+
         if not python_path.exists():
             raise FileNotFoundError(f"Python not found in virtual environment: {python_path}")
         

--- a/readme.md
+++ b/readme.md
@@ -60,9 +60,9 @@ project_root/
    python main.py
    ```
 
-### 3. **Set up environments (via GUI):**
-   - The GUI will guide you through virtual environment setup
-   - Or manually: Click "Setup All Environments" in the Environment Management tab
+### 3. **Start processing:**
+   - Starting either server will automatically create a dedicated virtual environment using `uv`
+   - You can also manually set up environments via the "Setup All Environments" button in the Environment Management tab
 
 ### 4. **Set Hugging Face token (for pyannote.audio models):**
    ```bash
@@ -81,17 +81,19 @@ project_root/
 
 ### Diarization Workflow
 
-1. **Start Diarization Server**: Creates isolated virtual environment with pyannote.audio
+1. **Start Diarization Server**: Automatically sets up an isolated environment with pyannote.audio
 2. **Process Audio**: Upload preprocessed audio for speaker diarization
 3. **Review Results**: Opens Label Studio browser for manual verification of speaker segments
 4. **Export RTTM**: Generate Rich Transcription Time Marked files for further processing
+5. **Stop Diarization Server**: Use the stop button to halt the server when finished
 
 ### Transcription Workflow (Framework Ready)
 
-1. **Start Transcription Server**: Creates isolated environment with NeMo ASR
+1. **Start Transcription Server**: Automatically sets up an isolated environment with NeMo ASR
 2. **Process Audio**: Upload preprocessed audio for speech recognition
 3. **Review Results**: Opens Label Studio browser for transcription correction
 4. **Export Text**: Generate timestamped transcriptions
+5. **Stop Transcription Server**: Use the stop button to halt the server when finished
 
 ## Key Features
 

--- a/tests/test_server_controls.py
+++ b/tests/test_server_controls.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from communication.server_manager import ServerManager, ServerType
+from ui.main_window import AudioProcessingApp
+
+
+def test_prepare_server_startup_creates_env(tmp_path, monkeypatch):
+    """ServerManager should create environment automatically when starting."""
+    manager = ServerManager()
+    manager.diarization_venv = tmp_path / "dia"
+
+    called = {}
+
+    def fake_setup():
+        called["setup"] = True
+        bin_dir = manager.diarization_venv / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "python").touch()
+
+    monkeypatch.setattr(manager, "_setup_diarization_environment", fake_setup)
+
+    python_path, script_path = manager._prepare_server_startup(ServerType.DIARIZATION)
+
+    assert called.get("setup") is True
+    assert Path(python_path).exists()
+    assert script_path.endswith("diarization/server.py")
+
+
+@patch("tkinter.Tk")
+def test_audio_processing_app_stop_servers(mock_tk):
+    """Stop server methods should invoke ServerManager and update status."""
+
+    def fake_setup_ui(self):
+        class DummyVar:
+            def __init__(self):
+                self.value = ""
+
+            def set(self, v):
+                self.value = v
+
+        self.diarization_status_var = DummyVar()
+        self.transcription_status_var = DummyVar()
+        self.start_diarization_server_btn = MagicMock()
+        self.stop_diarization_server_btn = MagicMock()
+        self.start_transcription_server_btn = MagicMock()
+        self.stop_transcription_server_btn = MagicMock()
+
+    with patch.object(AudioProcessingApp, "setup_ui", fake_setup_ui), \
+         patch.object(AudioProcessingApp, "setup_logging_display", return_value=None):
+        app = AudioProcessingApp()
+        with patch.object(app.server_manager, "stop_diarization_server") as mock_stop_d, \
+             patch.object(app.server_manager, "stop_transcription_server") as mock_stop_t:
+            app.stop_diarization_server()
+            app.stop_transcription_server()
+            mock_stop_d.assert_called_once()
+            mock_stop_t.assert_called_once()
+            assert app.diarization_status_var.value == "Server: Stopped | Browser: Not opened"
+            assert app.transcription_status_var.value == "Server: Stopped | Browser: Not opened"

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -156,13 +156,27 @@ class AudioProcessingApp:
                  font=("Arial", 12, "bold")).grid(row=0, column=0, columnspan=2, pady=(0, 10))
         
         # Server controls
-        self.diarization_server_btn = ttk.Button(parent, text="Start Diarization Server", 
-                                               command=self.toggle_diarization_server)
-        self.diarization_server_btn.grid(row=1, column=0, sticky=tk.W, padx=(0, 10))
-        
-        self.diarization_browser_btn = ttk.Button(parent, text="Open Label Studio (Diarization)", 
-                                                command=self.open_diarization_browser)
-        self.diarization_browser_btn.grid(row=1, column=1, sticky=tk.W)
+        self.start_diarization_server_btn = ttk.Button(
+            parent,
+            text="Start Diarization Server",
+            command=self.start_diarization_server,
+        )
+        self.start_diarization_server_btn.grid(row=1, column=0, sticky=tk.W, padx=(0, 10))
+
+        self.stop_diarization_server_btn = ttk.Button(
+            parent,
+            text="Stop Diarization Server",
+            command=self.stop_diarization_server,
+            state="disabled",
+        )
+        self.stop_diarization_server_btn.grid(row=1, column=1, sticky=tk.W, padx=(0, 10))
+
+        self.diarization_browser_btn = ttk.Button(
+            parent,
+            text="Open Label Studio (Diarization)",
+            command=self.open_diarization_browser,
+        )
+        self.diarization_browser_btn.grid(row=1, column=2, sticky=tk.W)
         
         # Processing controls
         run_diarization_btn = ttk.Button(parent, text="Run Diarization Pipeline", 
@@ -181,13 +195,27 @@ class AudioProcessingApp:
                  font=("Arial", 12, "bold")).grid(row=0, column=0, columnspan=2, pady=(0, 10))
         
         # Server controls
-        self.transcription_server_btn = ttk.Button(parent, text="Start Transcription Server", 
-                                                 command=self.toggle_transcription_server)
-        self.transcription_server_btn.grid(row=1, column=0, sticky=tk.W, padx=(0, 10))
-        
-        self.transcription_browser_btn = ttk.Button(parent, text="Open Label Studio (Transcription)", 
-                                                  command=self.open_transcription_browser)
-        self.transcription_browser_btn.grid(row=1, column=1, sticky=tk.W)
+        self.start_transcription_server_btn = ttk.Button(
+            parent,
+            text="Start Transcription Server",
+            command=self.start_transcription_server,
+        )
+        self.start_transcription_server_btn.grid(row=1, column=0, sticky=tk.W, padx=(0, 10))
+
+        self.stop_transcription_server_btn = ttk.Button(
+            parent,
+            text="Stop Transcription Server",
+            command=self.stop_transcription_server,
+            state="disabled",
+        )
+        self.stop_transcription_server_btn.grid(row=1, column=1, sticky=tk.W, padx=(0, 10))
+
+        self.transcription_browser_btn = ttk.Button(
+            parent,
+            text="Open Label Studio (Transcription)",
+            command=self.open_transcription_browser,
+        )
+        self.transcription_browser_btn.grid(row=1, column=2, sticky=tk.W)
         
         # Processing controls
         run_transcription_btn = ttk.Button(parent, text="Run Transcription Pipeline", 
@@ -315,53 +343,45 @@ class AudioProcessingApp:
         
         threading.Thread(target=preprocess_task, daemon=True).start()
     
-    def toggle_diarization_server(self):
-        """Toggle diarization server on/off."""
-        if self.server_manager.is_diarization_running():
-            self.server_manager.stop_diarization_server()
-            self.diarization_server_btn.config(text="Start Diarization Server")
-            self.diarization_status_var.set("Server: Stopped | Browser: Not opened")
-        else:
-            def start_server():
-                try:
-                    self.server_manager.start_diarization_server()
-                    self.root.after(0, lambda: self.diarization_server_btn.config(
-                        text="Stop Diarization Server"
-                    ))
-                    self.root.after(0, lambda: self.diarization_status_var.set(
-                        "Server: Running | Browser: Not opened"
-                    ))
-                except Exception as e:
-                    logger.error(f"Failed to start diarization server: {e}")
-                    self.root.after(0, lambda: messagebox.showerror(
-                        "Error", f"Failed to start server: {e}"
-                    ))
-            
-            threading.Thread(target=start_server, daemon=True).start()
-    
-    def toggle_transcription_server(self):
-        """Toggle transcription server on/off."""
-        if self.server_manager.is_transcription_running():
-            self.server_manager.stop_transcription_server()
-            self.transcription_server_btn.config(text="Start Transcription Server")
-            self.transcription_status_var.set("Server: Stopped | Browser: Not opened")
-        else:
-            def start_server():
-                try:
-                    self.server_manager.start_transcription_server()
-                    self.root.after(0, lambda: self.transcription_server_btn.config(
-                        text="Stop Transcription Server"
-                    ))
-                    self.root.after(0, lambda: self.transcription_status_var.set(
-                        "Server: Running | Browser: Not opened"
-                    ))
-                except Exception as e:
-                    logger.error(f"Failed to start transcription server: {e}")
-                    self.root.after(0, lambda: messagebox.showerror(
-                        "Error", f"Failed to start server: {e}"
-                    ))
-            
-            threading.Thread(target=start_server, daemon=True).start()
+    def start_diarization_server(self):
+        """Start the diarization server."""
+        def start_server():
+            try:
+                self.server_manager.start_diarization_server()
+                self.root.after(0, lambda: self.start_diarization_server_btn.config(state="disabled"))
+                self.root.after(0, lambda: self.stop_diarization_server_btn.config(state="normal"))
+                self.root.after(0, lambda: self.diarization_status_var.set("Server: Running | Browser: Not opened"))
+            except Exception as e:
+                logger.error(f"Failed to start diarization server: {e}")
+                self.root.after(0, lambda: messagebox.showerror("Error", f"Failed to start server: {e}"))
+        threading.Thread(target=start_server, daemon=True).start()
+
+    def stop_diarization_server(self):
+        """Stop the diarization server."""
+        self.server_manager.stop_diarization_server()
+        self.start_diarization_server_btn.config(state="normal")
+        self.stop_diarization_server_btn.config(state="disabled")
+        self.diarization_status_var.set("Server: Stopped | Browser: Not opened")
+
+    def start_transcription_server(self):
+        """Start the transcription server."""
+        def start_server():
+            try:
+                self.server_manager.start_transcription_server()
+                self.root.after(0, lambda: self.start_transcription_server_btn.config(state="disabled"))
+                self.root.after(0, lambda: self.stop_transcription_server_btn.config(state="normal"))
+                self.root.after(0, lambda: self.transcription_status_var.set("Server: Running | Browser: Not opened"))
+            except Exception as e:
+                logger.error(f"Failed to start transcription server: {e}")
+                self.root.after(0, lambda: messagebox.showerror("Error", f"Failed to start server: {e}"))
+        threading.Thread(target=start_server, daemon=True).start()
+
+    def stop_transcription_server(self):
+        """Stop the transcription server."""
+        self.server_manager.stop_transcription_server()
+        self.start_transcription_server_btn.config(state="normal")
+        self.stop_transcription_server_btn.config(state="disabled")
+        self.transcription_status_var.set("Server: Stopped | Browser: Not opened")
     
     def open_diarization_browser(self):
         """Open Label Studio browser for diarization."""
@@ -460,8 +480,10 @@ class AudioProcessingApp:
         """Clean up all running servers."""
         try:
             self.server_manager.cleanup_all()
-            self.diarization_server_btn.config(text="Start Diarization Server")
-            self.transcription_server_btn.config(text="Start Transcription Server")
+            self.start_diarization_server_btn.config(state="normal")
+            self.stop_diarization_server_btn.config(state="disabled")
+            self.start_transcription_server_btn.config(state="normal")
+            self.stop_transcription_server_btn.config(state="disabled")
             self.diarization_status_var.set("Server: Stopped | Browser: Not opened")
             self.transcription_status_var.set("Server: Stopped | Browser: Not opened")
             self.update_status("All servers stopped")


### PR DESCRIPTION
## Summary
- add dedicated start/stop buttons for diarization and transcription servers
- automatically create virtual environments with `uv` when servers launch
- document new workflow and add tests for server controls and environment creation

## Testing
- `pip install soundfile` *(fails: Could not find a version that satisfies the requirement soundfile)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'soundfile')*
- `pytest tests/test_server_controls.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b84f45edcc8333b2bcee3405c71f25