### PR TITLE
Add server stop controls and auto environment setup

### DIFF
--- a/communication/server_manager.py
+++ b/communication/server_manager.py
@@ -386,6 +386,14 @@ class ServerManager:
         try:
             self._ensure_runtime_dependencies()
             config = self.configs[server_type]
+
+            # Automatically create required virtual environment if missing
+            if server_type == ServerType.DIARIZATION and not self.diarization_venv.exists():
+                logger.info("Diarization environment not found. Creating with uv...")
+                self._setup_diarization_environment()
+            elif server_type == ServerType.TRANSCRIPTION and not self.transcription_venv.exists():
+                logger.info("Transcription environment not found. Creating with uv...")
+                self._setup_transcription_environment()
             
             # Update server info
             self.servers[server_type] = ServerInfo(

--- a/readme.md
+++ b/readme.md
@@ -61,8 +61,8 @@ project_root/
    ```
 
 ### 3. **Set up environments (via GUI):**
-   - The GUI will guide you through virtual environment setup
-   - Or manually: Click "Setup All Environments" in the Environment Management tab
+   - Starting a server automatically creates its virtual environment using `uv`
+   - You can also pre-create them via "Setup All Environments" in the Environment Management tab
 
 ### 4. **Set Hugging Face token (for pyannote.audio models):**
    ```bash
@@ -81,17 +81,19 @@ project_root/
 
 ### Diarization Workflow
 
-1. **Start Diarization Server**: Creates isolated virtual environment with pyannote.audio
+1. **Start Diarization Server**: Automatically creates an isolated environment with pyannote.audio using `uv`
 2. **Process Audio**: Upload preprocessed audio for speaker diarization
 3. **Review Results**: Opens Label Studio browser for manual verification of speaker segments
-4. **Export RTTM**: Generate Rich Transcription Time Marked files for further processing
+4. **Stop Diarization Server**: Use the dedicated stop button when finished
+5. **Export RTTM**: Generate Rich Transcription Time Marked files for further processing
 
 ### Transcription Workflow (Framework Ready)
 
-1. **Start Transcription Server**: Creates isolated environment with NeMo ASR
+1. **Start Transcription Server**: Automatically creates an isolated environment with NeMo ASR using `uv`
 2. **Process Audio**: Upload preprocessed audio for speech recognition
 3. **Review Results**: Opens Label Studio browser for transcription correction
-4. **Export Text**: Generate timestamped transcriptions
+4. **Stop Transcription Server**: Use the dedicated stop button when finished
+5. **Export Text**: Generate timestamped transcriptions
 
 ## Key Features
 

--- a/tests/test_server_environment.py
+++ b/tests/test_server_environment.py
@@ -1,0 +1,54 @@
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from communication.server_manager import ServerManager, ServerType
+
+
+@pytest.mark.parametrize(
+    "server_type, venv_attr, setup_method",
+    [
+        (ServerType.DIARIZATION, "diarization_venv", "_setup_diarization_environment"),
+        (ServerType.TRANSCRIPTION, "transcription_venv", "_setup_transcription_environment"),
+    ],
+)
+def test_environment_created_on_start(tmp_path, server_type, venv_attr, setup_method):
+    sm = ServerManager()
+    # Redirect venv paths to temporary directory
+    sm.venv_dir = tmp_path / ".venvs"
+    setattr(sm, venv_attr, sm.venv_dir / server_type.value)
+
+    # Create dummy server script location
+    work_dir = tmp_path / server_type.value
+    work_dir.mkdir()
+    (work_dir / "server.py").write_text("print('hello')")
+    sm.configs[server_type].working_directory = work_dir
+
+    mock_process = MagicMock()
+    mock_process.pid = 1234
+    mock_process.stdout = None
+    mock_process.stderr = None
+
+    dummy_script = work_dir / "server.py"
+
+    with patch.object(sm, setup_method) as mock_setup_env, \
+         patch.object(sm, "_ensure_runtime_dependencies"), \
+         patch.object(sm, "_start_health_monitor"), \
+         patch.object(sm, "_wait_for_server_startup", return_value=True), \
+         patch.object(sm, "_prepare_server_startup", return_value=("python", str(dummy_script))), \
+         patch("communication.server_manager.subprocess.Popen", return_value=mock_process):
+
+        def create_dummy_env():
+            python_path = getattr(sm, venv_attr) / ("Scripts" if os.name == "nt" else "bin") / "python"
+            python_path.parent.mkdir(parents=True, exist_ok=True)
+            python_path.touch()
+        mock_setup_env.side_effect = create_dummy_env
+
+        if server_type == ServerType.DIARIZATION:
+            assert sm.start_diarization_server()
+        else:
+            assert sm.start_transcription_server()
+
+        mock_setup_env.assert_called_once()

--- a/tests/test_ui_stop_buttons.py
+++ b/tests/test_ui_stop_buttons.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+
+from ui.main_window import AudioProcessingApp
+
+
+class DummyVar:
+    def __init__(self):
+        self.value = ""
+
+    def set(self, val):
+        self.value = val
+
+
+def test_stop_buttons_call_server_manager():
+    app = AudioProcessingApp.__new__(AudioProcessingApp)
+    app.server_manager = MagicMock()
+    app.diarization_status_var = DummyVar()
+    app.diarization_start_btn = MagicMock()
+    app.diarization_stop_btn = MagicMock()
+    app.stop_diarization_server()
+    app.server_manager.stop_diarization_server.assert_called_once()
+
+    app.server_manager = MagicMock()
+    app.transcription_status_var = DummyVar()
+    app.transcription_start_btn = MagicMock()
+    app.transcription_stop_btn = MagicMock()
+    app.stop_transcription_server()
+    app.server_manager.stop_transcription_server.assert_called_once()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -156,24 +156,29 @@ class AudioProcessingApp:
                  font=("Arial", 12, "bold")).grid(row=0, column=0, columnspan=2, pady=(0, 10))
         
         # Server controls
-        self.diarization_server_btn = ttk.Button(parent, text="Start Diarization Server", 
-                                               command=self.toggle_diarization_server)
-        self.diarization_server_btn.grid(row=1, column=0, sticky=tk.W, padx=(0, 10))
-        
-        self.diarization_browser_btn = ttk.Button(parent, text="Open Label Studio (Diarization)", 
+        self.diarization_start_btn = ttk.Button(parent, text="Start Diarization Server",
+                                               command=self.start_diarization_server)
+        self.diarization_start_btn.grid(row=1, column=0, sticky=tk.W, padx=(0, 10))
+
+        self.diarization_stop_btn = ttk.Button(parent, text="Stop Diarization Server",
+                                              command=self.stop_diarization_server,
+                                              state=tk.DISABLED)
+        self.diarization_stop_btn.grid(row=1, column=1, sticky=tk.W)
+
+        self.diarization_browser_btn = ttk.Button(parent, text="Open Label Studio (Diarization)",
                                                 command=self.open_diarization_browser)
-        self.diarization_browser_btn.grid(row=1, column=1, sticky=tk.W)
+        self.diarization_browser_btn.grid(row=2, column=0, sticky=tk.W, padx=(0, 10))
         
         # Processing controls
-        run_diarization_btn = ttk.Button(parent, text="Run Diarization Pipeline", 
+        run_diarization_btn = ttk.Button(parent, text="Run Diarization Pipeline",
                                        command=self.run_diarization)
-        run_diarization_btn.grid(row=2, column=0, pady=(10, 0), sticky=tk.W, padx=(0, 10))
+        run_diarization_btn.grid(row=3, column=0, pady=(10, 0), sticky=tk.W, padx=(0, 10))
         
         # Status display
         self.diarization_status_var = tk.StringVar(value="Server: Stopped | Browser: Not opened")
         diarization_status = ttk.Label(parent, textvariable=self.diarization_status_var, 
                                      foreground="red")
-        diarization_status.grid(row=3, column=0, columnspan=2, pady=(10, 0), sticky=tk.W)
+        diarization_status.grid(row=4, column=0, columnspan=2, pady=(10, 0), sticky=tk.W)
     
     def setup_transcription_controls(self, parent: ttk.Frame):
         """Set up transcription pipeline controls."""
@@ -181,24 +186,29 @@ class AudioProcessingApp:
                  font=("Arial", 12, "bold")).grid(row=0, column=0, columnspan=2, pady=(0, 10))
         
         # Server controls
-        self.transcription_server_btn = ttk.Button(parent, text="Start Transcription Server", 
-                                                 command=self.toggle_transcription_server)
-        self.transcription_server_btn.grid(row=1, column=0, sticky=tk.W, padx=(0, 10))
-        
-        self.transcription_browser_btn = ttk.Button(parent, text="Open Label Studio (Transcription)", 
+        self.transcription_start_btn = ttk.Button(parent, text="Start Transcription Server",
+                                                 command=self.start_transcription_server)
+        self.transcription_start_btn.grid(row=1, column=0, sticky=tk.W, padx=(0, 10))
+
+        self.transcription_stop_btn = ttk.Button(parent, text="Stop Transcription Server",
+                                                command=self.stop_transcription_server,
+                                                state=tk.DISABLED)
+        self.transcription_stop_btn.grid(row=1, column=1, sticky=tk.W)
+
+        self.transcription_browser_btn = ttk.Button(parent, text="Open Label Studio (Transcription)",
                                                   command=self.open_transcription_browser)
-        self.transcription_browser_btn.grid(row=1, column=1, sticky=tk.W)
+        self.transcription_browser_btn.grid(row=2, column=0, sticky=tk.W, padx=(0, 10))
         
         # Processing controls
-        run_transcription_btn = ttk.Button(parent, text="Run Transcription Pipeline", 
+        run_transcription_btn = ttk.Button(parent, text="Run Transcription Pipeline",
                                          command=self.run_transcription)
-        run_transcription_btn.grid(row=2, column=0, pady=(10, 0), sticky=tk.W, padx=(0, 10))
+        run_transcription_btn.grid(row=3, column=0, pady=(10, 0), sticky=tk.W, padx=(0, 10))
         
         # Status display
         self.transcription_status_var = tk.StringVar(value="Server: Stopped | Browser: Not opened")
         transcription_status = ttk.Label(parent, textvariable=self.transcription_status_var, 
                                        foreground="red")
-        transcription_status.grid(row=3, column=0, columnspan=2, pady=(10, 0), sticky=tk.W)
+        transcription_status.grid(row=4, column=0, columnspan=2, pady=(10, 0), sticky=tk.W)
     
     def setup_environment_controls(self, parent: ttk.Frame):
         """Set up virtual environment management controls."""
@@ -315,53 +325,63 @@ class AudioProcessingApp:
         
         threading.Thread(target=preprocess_task, daemon=True).start()
     
-    def toggle_diarization_server(self):
-        """Toggle diarization server on/off."""
-        if self.server_manager.is_diarization_running():
+    def start_diarization_server(self):
+        """Start the diarization server."""
+        def start_server():
+            try:
+                self.server_manager.start_diarization_server()
+                self.root.after(0, lambda: self.diarization_status_var.set(
+                    "Server: Running | Browser: Not opened"
+                ))
+                self.root.after(0, lambda: self.diarization_start_btn.config(state=tk.DISABLED))
+                self.root.after(0, lambda: self.diarization_stop_btn.config(state=tk.NORMAL))
+            except Exception as e:
+                logger.error(f"Failed to start diarization server: {e}")
+                self.root.after(0, lambda: messagebox.showerror(
+                    "Error", f"Failed to start server: {e}"
+                ))
+
+        threading.Thread(target=start_server, daemon=True).start()
+
+    def stop_diarization_server(self):
+        """Stop the diarization server."""
+        try:
             self.server_manager.stop_diarization_server()
-            self.diarization_server_btn.config(text="Start Diarization Server")
             self.diarization_status_var.set("Server: Stopped | Browser: Not opened")
-        else:
-            def start_server():
-                try:
-                    self.server_manager.start_diarization_server()
-                    self.root.after(0, lambda: self.diarization_server_btn.config(
-                        text="Stop Diarization Server"
-                    ))
-                    self.root.after(0, lambda: self.diarization_status_var.set(
-                        "Server: Running | Browser: Not opened"
-                    ))
-                except Exception as e:
-                    logger.error(f"Failed to start diarization server: {e}")
-                    self.root.after(0, lambda: messagebox.showerror(
-                        "Error", f"Failed to start server: {e}"
-                    ))
-            
-            threading.Thread(target=start_server, daemon=True).start()
-    
-    def toggle_transcription_server(self):
-        """Toggle transcription server on/off."""
-        if self.server_manager.is_transcription_running():
+            self.diarization_start_btn.config(state=tk.NORMAL)
+            self.diarization_stop_btn.config(state=tk.DISABLED)
+        except Exception as e:
+            logger.error(f"Failed to stop diarization server: {e}")
+            messagebox.showerror("Error", f"Failed to stop server: {e}")
+
+    def start_transcription_server(self):
+        """Start the transcription server."""
+        def start_server():
+            try:
+                self.server_manager.start_transcription_server()
+                self.root.after(0, lambda: self.transcription_status_var.set(
+                    "Server: Running | Browser: Not opened"
+                ))
+                self.root.after(0, lambda: self.transcription_start_btn.config(state=tk.DISABLED))
+                self.root.after(0, lambda: self.transcription_stop_btn.config(state=tk.NORMAL))
+            except Exception as e:
+                logger.error(f"Failed to start transcription server: {e}")
+                self.root.after(0, lambda: messagebox.showerror(
+                    "Error", f"Failed to start server: {e}"
+                ))
+
+        threading.Thread(target=start_server, daemon=True).start()
+
+    def stop_transcription_server(self):
+        """Stop the transcription server."""
+        try:
             self.server_manager.stop_transcription_server()
-            self.transcription_server_btn.config(text="Start Transcription Server")
             self.transcription_status_var.set("Server: Stopped | Browser: Not opened")
-        else:
-            def start_server():
-                try:
-                    self.server_manager.start_transcription_server()
-                    self.root.after(0, lambda: self.transcription_server_btn.config(
-                        text="Stop Transcription Server"
-                    ))
-                    self.root.after(0, lambda: self.transcription_status_var.set(
-                        "Server: Running | Browser: Not opened"
-                    ))
-                except Exception as e:
-                    logger.error(f"Failed to start transcription server: {e}")
-                    self.root.after(0, lambda: messagebox.showerror(
-                        "Error", f"Failed to start server: {e}"
-                    ))
-            
-            threading.Thread(target=start_server, daemon=True).start()
+            self.transcription_start_btn.config(state=tk.NORMAL)
+            self.transcription_stop_btn.config(state=tk.DISABLED)
+        except Exception as e:
+            logger.error(f"Failed to stop transcription server: {e}")
+            messagebox.showerror("Error", f"Failed to stop server: {e}")
     
     def open_diarization_browser(self):
         """Open Label Studio browser for diarization."""
@@ -460,8 +480,10 @@ class AudioProcessingApp:
         """Clean up all running servers."""
         try:
             self.server_manager.cleanup_all()
-            self.diarization_server_btn.config(text="Start Diarization Server")
-            self.transcription_server_btn.config(text="Start Transcription Server")
+            self.diarization_start_btn.config(state=tk.NORMAL)
+            self.diarization_stop_btn.config(state=tk.DISABLED)
+            self.transcription_start_btn.config(state=tk.NORMAL)
+            self.transcription_stop_btn.config(state=tk.DISABLED)
             self.diarization_status_var.set("Server: Stopped | Browser: Not opened")
             self.transcription_status_var.set("Server: Stopped | Browser: Not opened")
             self.update_status("All servers stopped")


### PR DESCRIPTION
## Summary
- add explicit start/stop controls for diarization and transcription servers
- automatically create virtual environments with uv when starting servers
- document new workflow and add tests for environment setup and stop buttons

## Testing
- `pytest tests/test_server_environment.py tests/test_ui_stop_buttons.py -q`
- `pytest -q` *(fails: No module named 'soundfile')*

------
https://chatgpt.com/codex/tasks/task_e_68b84f45edcc8333b2bcee3405c71f25