### PR TITLE
Handle missing psutil as optional dependency

### DIFF
--- a/communication/server_manager.py
+++ b/communication/server_manager.py
@@ -153,8 +153,6 @@ class ServerManager:
     def _ensure_runtime_dependencies(self):
         """Ensure optional runtime dependencies are available."""
         missing = []
-        if psutil is None:
-            missing.append("psutil")
         if requests is None:
             missing.append("requests")
         if missing:


### PR DESCRIPTION
## Summary
- avoid failing server startup when psutil isn't installed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest tests/test_server_environment.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03b46022c83338814c05b5a1b7c1b