### PR TITLE
Use temp directories for virtual envs and fix Windows Python path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ project_root/
 │   └── pipeline_controller.py # Workflow coordination
 ├── tests/                 # Unit and integration tests
 ├── configs/              # Environment configurations
-└── .venvs/              # Virtual environments (created by uv)
+└── <temp>/alf_venvs/    # Virtual environments (created by uv)
 ```
 
 ## Development Commands
@@ -56,8 +56,8 @@ project_root/
 ### Environment Setup
 ```bash
 # Setup virtual environments for different pipelines
-uv venv .venvs/diarization --python 3.9
-uv venv .venvs/transcription --python 3.9
+uv venv <temp>/alf_venvs/diarization --python 3.9
+uv venv <temp>/alf_venvs/transcription --python 3.9
 
 # Install dependencies (handled by server manager)
 # Dependencies listed in configs/diarization_env.txt and configs/transcription_env.txt
@@ -71,10 +71,10 @@ python main.py           # Start the unified GUI controller
 ### Manual Server Commands
 ```bash
 # Diarization server (runs in separate venv)
-cd diarization && ../venvs/diarization/bin/python server.py
+cd diarization && <temp>/alf_venvs/diarization/bin/python server.py
 
-# Transcription server (runs in separate venv)  
-cd transcription && ../venvs/transcription/bin/python server.py
+# Transcription server (runs in separate venv)
+cd transcription && <temp>/alf_venvs/transcription/bin/python server.py
 ```
 
 ### Testing
@@ -115,12 +115,12 @@ pytest tests/ -v
 - `soundfile`: Audio I/O
 - `pydub`: Audio format conversion
 
-### Diarization Environment (.venvs/diarization)
+### Diarization Environment (<temp>/alf_venvs/diarization)
 - `pyannote.audio>=3.0.0`: Speaker diarization
 - `torch>=2.0.0`: Deep learning backend
 - `scipy`: Signal processing
 
-### Transcription Environment (.venvs/transcription)  
+### Transcription Environment (<temp>/alf_venvs/transcription)
 - `nemo-toolkit[asr]>=1.20.0`: Speech recognition
 - `label-studio-ml>=1.0.9`: ML backend integration
 - `omegaconf`: Configuration management

--- a/communication/server_manager.py
+++ b/communication/server_manager.py
@@ -18,6 +18,7 @@ import signal
 import time
 import logging
 import shutil
+import tempfile
 try:
     import psutil  # type: ignore
 except ImportError:  # pragma: no cover - optional dependency
@@ -113,8 +114,8 @@ class ServerManager:
             )
         }
         
-        # Virtual environment paths
-        self.venv_dir = Path(".venvs")
+        # Virtual environment paths (use system temporary directory)
+        self.venv_dir = Path(tempfile.gettempdir()) / "alf_venvs"
         self.diarization_venv = self.venv_dir / "diarization"
         self.transcription_venv = self.venv_dir / "transcription"
 
@@ -136,7 +137,7 @@ class ServerManager:
         logger.info("Setting up virtual environments...")
         
         try:
-            # Create .venvs directory
+            # Create base temporary venv directory
             self.venv_dir.mkdir(exist_ok=True)
 
             # Setup diarization environment
@@ -205,7 +206,7 @@ class ServerManager:
                 raise RuntimeError(f"Failed to create diarization venv: {result.stderr}")
             
             # Install diarization dependencies using uv (faster than pip)
-            python_path = Path(self.diarization_venv) / ("Scripts/python" if os.name == 'nt' else "bin/python")
+            python_path = Path(self.diarization_venv) / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
             
             # Base dependencies for diarization
             base_deps = [
@@ -286,7 +287,7 @@ class ServerManager:
                 raise RuntimeError(f"Failed to create transcription venv: {result.stderr}")
             
             # Install transcription dependencies using uv (faster than pip)
-            python_path = Path(self.transcription_venv) / ("Scripts/python" if os.name == 'nt' else "bin/python")
+            python_path = Path(self.transcription_venv) / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
             
             # Use uv to install dependencies in the venv
             deps_file = Path("configs/transcription_env.txt")
@@ -345,7 +346,7 @@ class ServerManager:
         
         # Check diarization environment
         if Path(self.diarization_venv).exists():
-            python_path = Path(self.diarization_venv) / ("Scripts/python" if os.name == 'nt' else "bin/python")
+            python_path = Path(self.diarization_venv) / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
             if python_path.exists():
                 status_parts.append("✓ Diarization env: Ready")
             else:
@@ -355,7 +356,7 @@ class ServerManager:
         
         # Check transcription environment
         if Path(self.transcription_venv).exists():
-            python_path = Path(self.transcription_venv) / ("Scripts/python" if os.name == 'nt' else "bin/python")
+            python_path = Path(self.transcription_venv) / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
             if python_path.exists():
                 status_parts.append("✓ Transcription env: Ready")
             else:
@@ -405,7 +406,7 @@ class ServerManager:
             )
             
             # Use python from diarization venv since Label Studio is installed there
-            python_path = Path(self.diarization_venv) / ("Scripts/python" if os.name == 'nt' else "bin/python")
+            python_path = Path(self.diarization_venv) / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
             
             if not python_path.exists():
                 raise FileNotFoundError(f"Python not found in diarization environment: {python_path}")
@@ -583,11 +584,11 @@ class ServerManager:
             # Label Studio uses diarization venv but different command structure
             venv = Path(self.diarization_venv)
             # Label Studio doesn't use a script file, handled separately
-            return str(venv / ("Scripts/python" if os.name == 'nt' else "bin/python")), ""
+            return str(venv / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")), ""
         else:
             raise ValueError(f"Unknown server type: {server_type}")
         
-        python_path = venv / ("Scripts/python" if os.name == 'nt' else "bin/python")
+        python_path = venv / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
         
         if not python_path.exists():
             raise FileNotFoundError(f"Python not found in virtual environment: {python_path}")
@@ -857,7 +858,7 @@ class ServerManager:
         """
         Remove all virtual environments created by ALF.
         
-        This method safely removes the .venvs directory and all
+        This method safely removes the temporary venv directory and all
         virtual environments within it.
         """
         try:
@@ -866,7 +867,7 @@ class ServerManager:
             if self.venv_dir.exists():
                 logger.info(f"Removing virtual environments directory: {self.venv_dir}")
                 
-                # Remove the entire .venvs directory
+                # Remove the entire venv directory
                 shutil.rmtree(str(self.venv_dir))
                 
                 logger.info("Virtual environments removed successfully")
@@ -894,13 +895,13 @@ class ServerManager:
                     except Exception as e:
                         logger.error(f"Failed to remove {env_path.name}: {e}")
             
-            # Try to remove the parent .venvs directory if it's empty
+            # Try to remove the parent venv directory if it's empty
             try:
                 if self.venv_dir.exists() and not any(self.venv_dir.iterdir()):
                     self.venv_dir.rmdir()
-                    logger.info("Removed empty .venvs directory")
+                    logger.info("Removed empty venv directory")
             except Exception as e:
-                logger.warning(f"Could not remove .venvs directory: {e}")
+                logger.warning(f"Could not remove venv directory: {e}")
                 
         except Exception as e:
             logger.error(f"Failed to remove individual environments: {e}")

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ project_root/
 ├── configs/              # Virtual environment configurations
 │   ├── diarization_env.txt     # Diarization dependencies
 │   └── transcription_env.txt   # Transcription dependencies
-└── .venvs/               # Virtual environments (created at runtime)
+└── <temp>/alf_venvs/     # Virtual environments (created at runtime)
     ├── diarization/      # pyannote.audio environment
     └── transcription/    # NeMo ASR environment
 ```
@@ -145,12 +145,12 @@ Use the GUI "Setup All Environments" button which automatically:
 ### Manual Setup
 ```bash
 # Create diarization environment
-uv venv .venvs/diarization --python 3.9
-.venvs/diarization/bin/pip install -r configs/diarization_env.txt
+uv venv <temp>/alf_venvs/diarization --python 3.9
+<temp>/alf_venvs/diarization/bin/pip install -r configs/diarization_env.txt
 
 # Create transcription environment (when ready)
-uv venv .venvs/transcription --python 3.9
-.venvs/transcription/bin/pip install -r configs/transcription_env.txt
+uv venv <temp>/alf_venvs/transcription --python 3.9
+<temp>/alf_venvs/transcription/bin/pip install -r configs/transcription_env.txt
 ```
 
 ## Advanced Usage

--- a/tests/test_exit_functionality.py
+++ b/tests/test_exit_functionality.py
@@ -8,6 +8,7 @@ virtual environments and temporary files.
 import pytest
 import tempfile
 import shutil
+import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -22,16 +23,22 @@ class TestExitFunctionality:
         self.temp_dir = Path(tempfile.mkdtemp())
         
         # Create mock virtual environments for testing
-        self.mock_venvs_dir = self.temp_dir / ".venvs"
+        self.mock_venvs_dir = self.temp_dir / "venvs"
         self.mock_venvs_dir.mkdir()
         
         self.mock_diarization_env = self.mock_venvs_dir / "diarization"
         self.mock_diarization_env.mkdir()
         (self.mock_diarization_env / "pyvenv.cfg").write_text("test config")
-        
+        bin_dir = "Scripts" if os.name == "nt" else "bin"
+        py_name = "python.exe" if os.name == "nt" else "python"
+        (self.mock_diarization_env / bin_dir).mkdir()
+        (self.mock_diarization_env / bin_dir / py_name).touch()
+
         self.mock_transcription_env = self.mock_venvs_dir / "transcription"
         self.mock_transcription_env.mkdir()
         (self.mock_transcription_env / "pyvenv.cfg").write_text("test config")
+        (self.mock_transcription_env / bin_dir).mkdir()
+        (self.mock_transcription_env / bin_dir / py_name).touch()
     
     def teardown_method(self):
         """Clean up test fixtures."""
@@ -126,6 +133,9 @@ class TestExitFunctionality:
             app.server_manager.venv_dir = self.mock_venvs_dir
             app.server_manager.diarization_venv = self.mock_diarization_env
             app.server_manager.transcription_venv = self.mock_transcription_env
+            app.show_progress = MagicMock()
+            app.hide_progress = MagicMock()
+            app.update_status = MagicMock()
             
             # Mock the cleanup methods
             with patch.object(app.server_manager, 'cleanup_all_and_exit') as mock_cleanup_exit, \

--- a/tests/test_server_environment.py
+++ b/tests/test_server_environment.py
@@ -17,7 +17,7 @@ from communication.server_manager import ServerManager, ServerType
 def test_environment_created_on_start(tmp_path, server_type, venv_attr, setup_method):
     sm = ServerManager()
     # Redirect venv paths to temporary directory
-    sm.venv_dir = tmp_path / ".venvs"
+    sm.venv_dir = tmp_path / "venvs"
     setattr(sm, venv_attr, sm.venv_dir / server_type.value)
 
     # Create dummy server script location

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -533,7 +533,7 @@ class AudioProcessingApp:
             "Do you want to exit and remove all virtual environments?\n\n"
             "This will:\n"
             "• Stop all running servers\n"
-            "• Delete all virtual environments (.venvs directory)\n"
+            "• Delete all virtual environments (temporary directory)\n"
             "• Clean up temporary files\n"
             "• Close the application\n\n"
             "Click 'Yes' to exit with full cleanup\n"


### PR DESCRIPTION
## Summary
- Store diarization and transcription virtual environments under a system temporary directory instead of `.venvs`
- Correct Windows interpreter path to `Scripts/python.exe` for uv and status checks
- Update UI prompts, documentation, and tests for new temp-based environment paths

## Testing
- `pytest tests/test_server_environment.py tests/test_exit_functionality.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c04dcbc8dc833380721aaf3d856ce9