### PR TITLE
Include diarization server in build and resolve runtime path

### DIFF
--- a/alf_gui.spec
+++ b/alf_gui.spec
@@ -15,6 +15,7 @@ can dynamically install ML frameworks using uv in virtual environments.
 import sys
 import os
 from pathlib import Path
+from PyInstaller.utils.hooks import collect_data_files
 
 # Build configuration
 APP_NAME = "ALF-AudioProcessing"
@@ -47,6 +48,9 @@ datas = [
     ('readme.md', '.'),
     ('CLAUDE.md', '.'),
 ]
+
+# Include diarization server resources
+datas += collect_data_files('diarization', include_py_files=True)
 
 # Include uv executable if found
 binaries = []

--- a/audio_processing/preprocessing.py
+++ b/audio_processing/preprocessing.py
@@ -253,25 +253,32 @@ class AudioPreprocessor:
             raise ValueError(f"Invalid input directory: {input_dir}")
         
         processed_files = []
-        
+
         # Find all audio files
         audio_files = []
         for ext in file_extensions:
             audio_files.extend(input_dir.glob(f"*{ext}"))
             audio_files.extend(input_dir.glob(f"*{ext.upper()}"))
-        
+
         logger.info(f"Found {len(audio_files)} audio files to process")
-        
+
+        self._load_dependencies()
+        sf = self.sf
+
         # Process each file
         for audio_file in audio_files:
             try:
+                audio_data, _ = sf.read(str(audio_file))
+                if audio_data.ndim != 1:
+                    logger.info(f"Skipping non-mono file: {audio_file.name}")
+                    continue
                 processed_path = self.preprocess_mp3_to_mono_16k(audio_file)
                 processed_files.append(processed_path)
                 logger.info(f"Successfully processed: {audio_file.name}")
             except Exception as e:
                 logger.error(f"Failed to process {audio_file.name}: {e}")
                 continue
-        
+
         logger.info(f"Batch processing completed: {len(processed_files)}/{len(audio_files)} files")
         return processed_files
     

--- a/communication/json_protocol.py
+++ b/communication/json_protocol.py
@@ -14,6 +14,7 @@ The protocol provides standardized message formats for:
 
 import json
 import logging
+import queue
 from typing import Dict, Any, Optional, List, Union
 from datetime import datetime
 from enum import Enum
@@ -483,7 +484,6 @@ class MessageQueue:
     
     def __init__(self, maxsize: int = 100):
         """Initialize message queue with maximum size."""
-        import queue
         self.queue = queue.Queue(maxsize=maxsize)
         self.logger = logging.getLogger(f"{__name__}.MessageQueue")
     

--- a/communication/server_manager.py
+++ b/communication/server_manager.py
@@ -575,11 +575,11 @@ class ServerManager:
         if server_type == ServerType.DIARIZATION:
             venv = Path(self.diarization_venv)
             script = "server.py"
-            script_path = Path(server_type.value) / script
+            script_rel = Path(server_type.value) / script
         elif server_type == ServerType.TRANSCRIPTION:
-            venv = Path(self.transcription_venv)  
+            venv = Path(self.transcription_venv)
             script = "server.py"
-            script_path = Path(server_type.value) / script
+            script_rel = Path(server_type.value) / script
         elif server_type == ServerType.LABEL_STUDIO:
             # Label Studio uses diarization venv but different command structure
             venv = Path(self.diarization_venv)
@@ -589,13 +589,20 @@ class ServerManager:
             raise ValueError(f"Unknown server type: {server_type}")
         
         python_path = venv / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
-        
+
+        # Determine actual script location (handles PyInstaller bundles)
+        base_dir = Path(sys._MEIPASS) if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS') else Path.cwd()
+        script_path = base_dir / script_rel
+
+        # Update working directory to script location
+        self.configs[server_type].working_directory = script_path.parent
+
         if not python_path.exists():
             raise FileNotFoundError(f"Python not found in virtual environment: {python_path}")
-        
+
         if not script_path.exists():
             raise FileNotFoundError(f"Server script not found: {script_path}")
-        
+
         return str(python_path), str(script_path)
     
     def _wait_for_server_startup(self, server_type: ServerType, timeout: int) -> bool:

--- a/ui/pipeline_controller.py
+++ b/ui/pipeline_controller.py
@@ -95,7 +95,9 @@ class PipelineController:
             
             logger.info(f"Diarization pipeline completed for job: {job_id}")
             return result
-            
+
+        except FileNotFoundError:
+            raise
         except Exception as e:
             logger.error(f"Diarization pipeline failed: {e}")
             raise RuntimeError(f"Diarization pipeline error: {e}")


### PR DESCRIPTION
## Summary
- Bundle the diarization server via `collect_data_files` so `server.py` is present in frozen builds
- Propagate `FileNotFoundError` from diarization pipeline instead of wrapping it
- Import `queue` globally for message queue handling
- Skip non-mono files during batch preprocessing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c130220c288333ae2daee762452a6d