### PR TITLE
Improve server startup handling and env setup

### DIFF
--- a/communication/server_manager.py
+++ b/communication/server_manager.py
@@ -98,7 +98,8 @@ class ServerManager:
                 server_type=ServerType.DIARIZATION,
                 port=9091,
                 working_directory=Path("diarization"),
-                health_check_endpoint="/health"
+                health_check_endpoint="/health",
+                startup_timeout=120,
             ),
             ServerType.TRANSCRIPTION: ServerConfig(
                 server_type=ServerType.TRANSCRIPTION,
@@ -110,7 +111,8 @@ class ServerManager:
                 server_type=ServerType.LABEL_STUDIO,
                 port=8080,
                 working_directory=Path("."),
-                health_check_endpoint="/version"
+                health_check_endpoint="/api/version",
+                startup_timeout=60,
             )
         }
         
@@ -438,12 +440,18 @@ class ServerManager:
         Returns:
             bool: True if server started successfully
         """
+        if not Path(self.diarization_venv).exists():
+            logger.info("Diarization environment not found. Creating with uv...")
+            self._setup_diarization_environment()
+
         success = self._start_server(ServerType.DIARIZATION)
-        
+
         if success and with_label_studio:
             # Start Label Studio in the same environment
-            self._start_label_studio_server()
-        
+            if not self._start_label_studio_server():
+                logger.error("Label Studio failed to start")
+                return False
+
         return success
 
 
@@ -546,10 +554,14 @@ class ServerManager:
     def start_transcription_server(self) -> bool:
         """
         Start the transcription server.
-        
+
         Returns:
             bool: True if server started successfully
         """
+        if not Path(self.transcription_venv).exists():
+            logger.info("Transcription environment not found. Creating with uv...")
+            self._setup_transcription_environment()
+
         return self._start_server(ServerType.TRANSCRIPTION)
     
     def _start_server(self, server_type: ServerType) -> bool:
@@ -569,14 +581,6 @@ class ServerManager:
         try:
             self._ensure_runtime_dependencies()
             config = self.configs[server_type]
-
-            # Automatically create required virtual environment if missing
-            if server_type == ServerType.DIARIZATION and not Path(self.diarization_venv).exists():
-                logger.info("Diarization environment not found. Creating with uv...")
-                self._setup_diarization_environment(include_label_studio=True)
-            elif server_type == ServerType.TRANSCRIPTION and not Path(self.transcription_venv).exists():
-                logger.info("Transcription environment not found. Creating with uv...")
-                self._setup_transcription_environment()
             
             # Update server info
             self.servers[server_type] = ServerInfo(

--- a/ui/pipeline_controller.py
+++ b/ui/pipeline_controller.py
@@ -72,8 +72,11 @@ class PipelineController:
             # Ensure diarization server is running
             if not self.server_manager.is_diarization_running():
                 logger.info("Starting diarization server...")
-                if not self.server_manager.start_diarization_server():
-                    raise RuntimeError("Failed to start diarization server")
+                try:
+                    if not self.server_manager.start_diarization_server():
+                        raise RuntimeError("server unavailable")
+                except Exception:
+                    raise RuntimeError("server unavailable")
             
             # Create processing request
             job_id = self._generate_job_id("diarization")
@@ -130,8 +133,11 @@ class PipelineController:
             # Ensure transcription server is running
             if not self.server_manager.is_transcription_running():
                 logger.info("Starting transcription server...")
-                if not self.server_manager.start_transcription_server():
-                    raise RuntimeError("Failed to start transcription server")
+                try:
+                    if not self.server_manager.start_transcription_server():
+                        raise RuntimeError("server unavailable")
+                except Exception:
+                    raise RuntimeError("server unavailable")
             
             # Create processing request
             job_id = self._generate_job_id("transcription")


### PR DESCRIPTION
## Summary
- increase default startup timeouts and correct Label Studio health check
- ensure diarization and transcription environments are created explicitly before starting
- propagate server availability errors through pipeline controller

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1a79e2c988333a3819b2ba301f95b