### PR TITLE
Improve server startup handling and env setup

### DIFF
--- a/communication/server_manager.py
+++ b/communication/server_manager.py
@@ -98,7 +98,8 @@ class ServerManager:
                 server_type=ServerType.DIARIZATION,
                 port=9091,
                 working_directory=Path("diarization"),
-                health_check_endpoint="/health"
+                health_check_endpoint="/health",
+                startup_timeout=120,
             ),
             ServerType.TRANSCRIPTION: ServerConfig(
                 server_type=ServerType.TRANSCRIPTION,
@@ -110,7 +111,8 @@ class ServerManager:
                 server_type=ServerType.LABEL_STUDIO,
                 port=8080,
                 working_directory=Path("."),
-                health_check_endpoint="/version"
+                health_check_endpoint="/api/version",
+                startup_timeout=60,
             )
         }
         
@@ -438,12 +440,18 @@ class ServerManager:
         Returns:
             bool: True if server started successfully
         """
+        if not Path(self.diarization_venv).exists():
+            logger.info("Diarization environment not found. Creating with uv...")
+            self._setup_diarization_environment()
+
         success = self._start_server(ServerType.DIARIZATION)
-        
+
         if success and with_label_studio:
             # Start Label Studio in the same environment
-            self._start_label_studio_server()
-        
+            if not self._start_label_studio_server():
+                logger.error("Label Studio failed to start")
+                return False
+
         return success
 
 
@@ -546,10 +554,14 @@ class ServerManager:
     def start_transcription_server(self) -> bool:
         """
         Start the transcription server.
-        
+
         Returns:
             bool: True if server started successfully
         """
+        if not Path(self.transcription_venv).exists():
+            logger.info("Transcription environment not found. Creating with uv...")
+            self._setup_transcription_environment()
+
         return self._start_server(ServerType.TRANSCRIPTION)
     
     def _start_server(self, server_type: ServerType) -> bool:
@@ -569,14 +581,6 @@ class ServerManager:
         try:
             self._ensure_runtime_dependencies()
             config = self.configs[server_type]
-
-            # Automatically create required virtual environment if missing
-            if server_type == ServerType.DIARIZATION and not Path(self.diarization_venv).exists():
-                logger.info("Diarization environment not found. Creating with uv...")
-                self._setup_diarization_environment(include_label_studio=True)
-            elif server_type == ServerType.TRANSCRIPTION and not Path(self.transcription_venv).exists():
-                logger.info("Transcription environment not found. Creating with uv...")
-                self._setup_transcription_environment()
             
             # Update server info
             self.servers[server_type] = ServerInfo(

--- a/diarization/server.py
+++ b/diarization/server.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import logging
 import tempfile
 import json
+import asyncio
 from typing import Dict, Any, List, Optional
 from datetime import datetime
 
@@ -89,31 +90,32 @@ diarization_pipeline: Optional[DiarizationPipeline] = None
 rttm_handler: Optional[RTTMHandler] = None
 server_start_time: float = 0.0
 active_jobs: Dict[str, Dict[str, Any]] = {}
+init_task: Optional[asyncio.Task] = None
 
 @app.on_event("startup")
 async def startup_event():
     """Initialize server components on startup."""
-    global json_protocol, diarization_pipeline, rttm_handler, server_start_time
-    
+    global json_protocol, diarization_pipeline, rttm_handler, server_start_time, init_task
+
     logger.info("Starting ALF Diarization Server...")
     server_start_time = datetime.now().timestamp()
-    
+
     try:
         # Initialize communication protocol
         json_protocol = JsonProtocol()
         logger.info("JSON protocol initialized")
-        
+
         # Initialize RTTM handler
         rttm_handler = RTTMHandler()
         logger.info("RTTM handler initialized")
-        
-        # Initialize diarization pipeline
+
+        # Initialize diarization pipeline in background
         diarization_pipeline = DiarizationPipeline()
-        await diarization_pipeline.initialize()
-        logger.info("Diarization pipeline initialized")
-        
+        init_task = asyncio.create_task(diarization_pipeline.initialize())
+        logger.info("Diarization pipeline initialization started")
+
         logger.info("Diarization server startup completed")
-        
+
     except Exception as e:
         logger.error(f"Server startup failed: {e}")
         sys.exit(1)
@@ -122,7 +124,10 @@ async def startup_event():
 async def shutdown_event():
     """Clean up resources on shutdown."""
     logger.info("Shutting down ALF Diarization Server...")
-    
+
+    if init_task and not init_task.done():
+        await init_task
+
     if diarization_pipeline:
         await diarization_pipeline.cleanup()
     
@@ -137,9 +142,12 @@ async def health_check():
         HealthResponse: Server health status
     """
     uptime = datetime.now().timestamp() - server_start_time
-    
+    status = "initializing"
+    if diarization_pipeline and getattr(diarization_pipeline, "is_initialized", False):
+        status = "healthy"
+
     return HealthResponse(
-        status="healthy",
+        status=status,
         service="diarization",
         version="0.2.0",
         uptime_seconds=uptime
@@ -162,7 +170,11 @@ async def process_diarization(
     """
     if not diarization_pipeline:
         raise HTTPException(status_code=503, detail="Diarization pipeline not initialized")
-    
+
+    if not diarization_pipeline.is_initialized and init_task:
+        logger.info("Waiting for diarization pipeline to finish initialization")
+        await init_task
+
     # Validate input file
     audio_path = Path(request.audio_file_path)
     if not audio_path.exists():
@@ -397,5 +409,5 @@ if __name__ == "__main__":
         host=host,
         port=port,
         reload=False,
-        log_level="info"
+        log_level="info",
     )

--- a/ui/pipeline_controller.py
+++ b/ui/pipeline_controller.py
@@ -72,8 +72,11 @@ class PipelineController:
             # Ensure diarization server is running
             if not self.server_manager.is_diarization_running():
                 logger.info("Starting diarization server...")
-                if not self.server_manager.start_diarization_server():
-                    raise RuntimeError("Failed to start diarization server")
+                try:
+                    if not self.server_manager.start_diarization_server():
+                        raise RuntimeError("server unavailable")
+                except Exception:
+                    raise RuntimeError("server unavailable")
             
             # Create processing request
             job_id = self._generate_job_id("diarization")
@@ -130,8 +133,11 @@ class PipelineController:
             # Ensure transcription server is running
             if not self.server_manager.is_transcription_running():
                 logger.info("Starting transcription server...")
-                if not self.server_manager.start_transcription_server():
-                    raise RuntimeError("Failed to start transcription server")
+                try:
+                    if not self.server_manager.start_transcription_server():
+                        raise RuntimeError("server unavailable")
+                except Exception:
+                    raise RuntimeError("server unavailable")
             
             # Create processing request
             job_id = self._generate_job_id("transcription")


### PR DESCRIPTION
## Summary
- increase default startup timeouts and correct Label Studio health check
- ensure diarization and transcription environments are created explicitly before starting
- propagate server availability errors through pipeline controller
- initialize diarization pipeline asynchronously and expose initialization status via health check

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a79e2c988333a3819b2ba301f95b