### PR TITLE
Improve server startup handling and env setup

### DIFF
--- a/communication/server_manager.py
+++ b/communication/server_manager.py
@@ -98,7 +98,8 @@ class ServerManager:
                 server_type=ServerType.DIARIZATION,
                 port=9091,
                 working_directory=Path("diarization"),
-                health_check_endpoint="/health"
+                health_check_endpoint="/health",
+                startup_timeout=120,
             ),
             ServerType.TRANSCRIPTION: ServerConfig(
                 server_type=ServerType.TRANSCRIPTION,
@@ -110,7 +111,8 @@ class ServerManager:
                 server_type=ServerType.LABEL_STUDIO,
                 port=8080,
                 working_directory=Path("."),
-                health_check_endpoint="/version"
+                health_check_endpoint="/api/version",
+                startup_timeout=60,
             )
         }
         
@@ -118,6 +120,7 @@ class ServerManager:
         self.venv_dir = Path(tempfile.gettempdir()) / "alf_venvs"
         self.diarization_venv = self.venv_dir / "diarization"
         self.transcription_venv = self.venv_dir / "transcription"
+        self.label_studio_venv = self.venv_dir / "label_studio"
 
         logger.info("ServerManager initialized")
         if psutil is None or requests is None:
@@ -140,10 +143,9 @@ class ServerManager:
             # Create base temporary venv directory
             self.venv_dir.mkdir(exist_ok=True)
 
-            # Setup diarization environment (with Label Studio)
-            self._setup_diarization_environment(include_label_studio=True)
-
-            # Setup transcription environment
+            # Setup diarization, label studio, and transcription environments
+            self._setup_diarization_environment()
+            self._setup_label_studio_environment()
             self._setup_transcription_environment()
 
             logger.info("Virtual environments setup completed")
@@ -186,12 +188,8 @@ class ServerManager:
 
         raise RuntimeError("uv package manager not found. Please install uv with: curl -LsSf https://astral.sh/uv/install.sh | sh")
     
-    def _setup_diarization_environment(self, include_label_studio=True):
-        """Set up the diarization virtual environment with Label Studio.
-        
-        Args:
-            include_label_studio (bool): Whether to include Label Studio installation
-        """
+    def _setup_diarization_environment(self):
+        """Set up the diarization virtual environment."""
         logger.info("Setting up diarization environment...")
         
         try:
@@ -223,7 +221,7 @@ class ServerManager:
             # Base dependencies for diarization
             base_deps = [
                 "fastapi[standard]>=0.100.0",
-                "uvicorn>=0.23.0", 
+                "uvicorn>=0.23.0",
                 "pyannote.audio>=3.0.0",
                 "pyannote.core>=5.0.0",
                 "torch>=2.0.0",
@@ -234,18 +232,12 @@ class ServerManager:
                 "pydantic>=2.0.0"
             ]
             
-            # Add Label Studio if requested
-            if include_label_studio:
-                logger.info("Including Label Studio for diarization annotation...")
-                base_deps.append("label-studio>=1.10.0")
-                base_deps.append("label-studio-sdk>=0.0.32")
-            
             # Use uv to install dependencies in the venv
             deps_file = Path("configs/diarization_env.txt")
-            if deps_file.exists() and not include_label_studio:
+            if deps_file.exists():
                 cmd = [uv_exe, "pip", "install", "-p", str(python_path), "-r", str(deps_file)]
                 result = subprocess.run(cmd, capture_output=True, text=True)
-                
+
                 if result.returncode != 0:
                     logger.warning(f"uv installation failed, falling back to pip: {result.stderr}")
                     # Fallback to pip installation
@@ -253,14 +245,11 @@ class ServerManager:
                 else:
                     logger.info("Dependencies installed successfully with uv")
             else:
-                if include_label_studio:
-                    logger.info("Installing diarization packages including Label Studio...")
-                else:
-                    logger.info("Installing diarization packages (without Label Studio)...")
+                logger.info("Installing diarization packages...")
                 # Install all dependencies at once using uv (more efficient)
                 cmd = [uv_exe, "pip", "install", "-p", str(python_path)] + base_deps
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)  # 10 minute timeout
-                
+
                 if result.returncode != 0:
                     logger.warning(f"Batch uv installation failed, trying individual pip installs: {result.stderr}")
                     # Fallback to pip installation one by one
@@ -285,6 +274,40 @@ class ServerManager:
                 logger.warning(f"Failed to install {dep}: {result.stderr}")
             else:
                 logger.debug(f"Successfully installed: {dep}")
+
+    def _setup_label_studio_environment(self):
+        """Set up the Label Studio virtual environment."""
+        logger.info("Setting up Label Studio environment...")
+
+        try:
+            uv_exe = self._get_uv_executable()
+
+            # Create environment using uv
+            cmd = [uv_exe, "venv", str(Path(self.label_studio_venv)), "--python", "3.9"]
+            logger.info(f"Creating virtual environment with command: {' '.join(cmd)}")
+            result = subprocess.run(cmd, capture_output=True, text=True)
+
+            if result.returncode != 0:
+                logger.error(f"Failed to create Label Studio venv: {result.stderr}")
+                raise RuntimeError(f"Failed to create Label Studio venv: {result.stderr}")
+
+            python_path = Path(self.label_studio_venv) / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
+
+            logger.info("Installing Label Studio in its environment...")
+            cmd = [uv_exe, "pip", "install", "-p", str(python_path), "label-studio>=1.10.0"]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+            if result.returncode != 0:
+                logger.warning(f"uv installation failed, falling back to pip: {result.stderr}")
+                self._install_deps_with_pip(self.label_studio_venv, ["label-studio>=1.10.0"])
+            else:
+                logger.info("Label Studio installed successfully with uv")
+
+            logger.info("Label Studio environment setup completed")
+
+        except Exception as e:
+            logger.error(f"Label Studio environment setup failed: {e}")
+            raise
     
     def _setup_transcription_environment(self):
         """Set up the transcription virtual environment."""
@@ -392,31 +415,37 @@ class ServerManager:
         info = {
             "venv_base_dir": str(self.venv_dir),
             "diarization_venv_path": str(self.diarization_venv),
+            "label_studio_venv_path": str(self.label_studio_venv),
             "venv_base_exists": self.venv_dir.exists(),
             "diarization_venv_exists": Path(self.diarization_venv).exists(),
-            "python_path": None,
-            "python_exists": False,
+            "label_studio_venv_exists": Path(self.label_studio_venv).exists(),
+            "diarization_python_path": None,
+            "diarization_python_exists": False,
+            "label_studio_python_path": None,
+            "label_studio_python_exists": False,
             "label_studio_installed": False,
             "uv_executable": None,
             "uv_available": False
         }
-        
-        # Check if python exists in venv
+
+        # Check if python exists in diarization venv
         python_path = Path(self.diarization_venv) / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
-        info["python_path"] = str(python_path)
-        info["python_exists"] = python_path.exists()
-        
-        # Check if Label Studio is installed (in diarization environment)
-        if info["python_exists"]:
+        info["diarization_python_path"] = str(python_path)
+        info["diarization_python_exists"] = python_path.exists()
+
+        # Check python in Label Studio venv
+        ls_python_path = Path(self.label_studio_venv) / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
+        info["label_studio_python_path"] = str(ls_python_path)
+        info["label_studio_python_exists"] = ls_python_path.exists()
+
+        # Check if Label Studio is installed (in its own environment)
+        if info["label_studio_python_exists"]:
             try:
-                import subprocess
-                result = subprocess.run([str(python_path), "-c", "import label_studio; print('installed')"], 
+                result = subprocess.run([str(ls_python_path), "-c", "import label_studio; print('installed')"],
                                       capture_output=True, text=True, timeout=5)
                 info["label_studio_installed"] = (result.returncode == 0)
-            except:
+            except Exception:
                 info["label_studio_installed"] = False
-        else:
-            info["label_studio_installed"] = False
         
         # Check uv availability
         try:
@@ -428,23 +457,47 @@ class ServerManager:
             
         return info
     
-    def start_diarization_server(self, with_label_studio=True) -> bool:
+    def start_diarization_server(self, with_label_studio: bool = True) -> bool:
+        """Start the diarization server.
+
+        Parameters
+        ----------
+        with_label_studio: bool, optional
+            If ``True`` (default), ensure the Label Studio frontend is also
+            running. The frontend will be started even if the diarization
+            backend fails to come up so that annotation can continue
+            independently.
+
+        Returns
+        -------
+        bool
+            ``True`` if the diarization backend started successfully.
         """
-        Start the diarization server with optional Label Studio.
-        
-        Args:
-            with_label_studio (bool): Whether to also start Label Studio
-            
-        Returns:
-            bool: True if server started successfully
-        """
+        if not Path(self.diarization_venv).exists():
+            logger.info("Diarization environment not found. Creating with uv...")
+            self._setup_diarization_environment()
+
         success = self._start_server(ServerType.DIARIZATION)
-        
-        if success and with_label_studio:
-            # Start Label Studio in the same environment
-            self._start_label_studio_server()
-        
+
+        if with_label_studio:
+            # Start Label Studio independently of the diarization backend
+            if not self.start_label_studio_server():
+                logger.error("Label Studio failed to start")
+
         return success
+
+
+    def start_label_studio_server(self) -> bool:
+        """Public wrapper to start the Label Studio server.
+
+        Ensures the Label Studio virtual environment exists before
+        delegating to the internal startup routine.
+        """
+        if not Path(self.label_studio_venv).exists():
+            logger.info("Label Studio environment not found. Creating with uv...")
+            self._setup_label_studio_environment()
+
+        return self._start_label_studio_server()
 
 
     def _start_label_studio_server(self) -> bool:
@@ -469,7 +522,7 @@ class ServerManager:
             )
             
             # Use python from Label Studio's own virtual environment
-            python_path = Path(self.diarization_venv) / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
+            python_path = Path(self.label_studio_venv) / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")
             
             if not python_path.exists():
                 raise FileNotFoundError(f"Python not found in Label Studio environment: {python_path}")
@@ -546,10 +599,14 @@ class ServerManager:
     def start_transcription_server(self) -> bool:
         """
         Start the transcription server.
-        
+
         Returns:
             bool: True if server started successfully
         """
+        if not Path(self.transcription_venv).exists():
+            logger.info("Transcription environment not found. Creating with uv...")
+            self._setup_transcription_environment()
+
         return self._start_server(ServerType.TRANSCRIPTION)
     
     def _start_server(self, server_type: ServerType) -> bool:
@@ -569,14 +626,6 @@ class ServerManager:
         try:
             self._ensure_runtime_dependencies()
             config = self.configs[server_type]
-
-            # Automatically create required virtual environment if missing
-            if server_type == ServerType.DIARIZATION and not Path(self.diarization_venv).exists():
-                logger.info("Diarization environment not found. Creating with uv...")
-                self._setup_diarization_environment(include_label_studio=True)
-            elif server_type == ServerType.TRANSCRIPTION and not Path(self.transcription_venv).exists():
-                logger.info("Transcription environment not found. Creating with uv...")
-                self._setup_transcription_environment()
             
             # Update server info
             self.servers[server_type] = ServerInfo(
@@ -617,15 +666,29 @@ class ServerManager:
             if self._wait_for_server_startup(server_type, config.startup_timeout):
                 self.servers[server_type].state = ServerState.RUNNING
                 self.servers[server_type].pid = process.pid
-                
+
                 # Start health monitoring
                 self._start_health_monitor(server_type)
-                
+
                 logger.info(f"{server_type.value} server started successfully (PID: {process.pid})")
                 return True
             else:
+                # Capture any output from the failed process for debugging
+                try:
+                    stdout, stderr = process.communicate(timeout=5)
+                except Exception:
+                    stdout, stderr = "", ""
+
+                if stdout:
+                    logger.error(f"{server_type.value} server stdout:\n{stdout}")
+                if stderr:
+                    logger.error(f"{server_type.value} server stderr:\n{stderr}")
+
                 self.servers[server_type].state = ServerState.ERROR
-                self.servers[server_type].error_message = "Server failed to start within timeout"
+                self.servers[server_type].error_message = (
+                    "Server failed to start within timeout. "
+                    f"stdout: {stdout.strip()} stderr: {stderr.strip()}"
+                )
                 self._cleanup_failed_process(server_type)
                 return False
                 
@@ -658,7 +721,7 @@ class ServerManager:
             script_rel = Path(server_type.value) / script
         elif server_type == ServerType.LABEL_STUDIO:
             # Label Studio uses its own separate virtual environment
-            venv = Path(self.diarization_venv)
+            venv = Path(self.label_studio_venv)
             # Label Studio doesn't use a script file, handled separately
             return str(venv / ("Scripts/python.exe" if os.name == 'nt' else "bin/python")), ""
         else:
@@ -761,6 +824,8 @@ class ServerManager:
         if cleanup_venv and success:
             logger.info("Cleaning up diarization virtual environment...")
             self._cleanup_diarization_environment()
+            logger.info("Cleaning up Label Studio virtual environment...")
+            self._cleanup_label_studio_environment()
         
         return success
 
@@ -777,6 +842,20 @@ class ServerManager:
 
         except Exception as e:
             logger.error(f"Failed to remove diarization virtual environment: {e}")
+
+    def _cleanup_label_studio_environment(self):
+        """Clean up the Label Studio virtual environment."""
+        try:
+            venv_path = Path(self.label_studio_venv)
+            if venv_path.exists() and venv_path.is_dir():
+                logger.info(f"Removing Label Studio virtual environment: {venv_path}")
+                shutil.rmtree(str(venv_path))
+                logger.info("Label Studio virtual environment removed successfully")
+            else:
+                logger.info("No Label Studio virtual environment found to remove")
+
+        except Exception as e:
+            logger.error(f"Failed to remove Label Studio virtual environment: {e}")
     
     def stop_transcription_server(self) -> bool:
         """Stop the transcription server."""

--- a/diarization/server.py
+++ b/diarization/server.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import logging
 import tempfile
 import json
+import asyncio
 from typing import Dict, Any, List, Optional
 from datetime import datetime
 
@@ -89,31 +90,32 @@ diarization_pipeline: Optional[DiarizationPipeline] = None
 rttm_handler: Optional[RTTMHandler] = None
 server_start_time: float = 0.0
 active_jobs: Dict[str, Dict[str, Any]] = {}
+init_task: Optional[asyncio.Task] = None
 
 @app.on_event("startup")
 async def startup_event():
     """Initialize server components on startup."""
-    global json_protocol, diarization_pipeline, rttm_handler, server_start_time
-    
+    global json_protocol, diarization_pipeline, rttm_handler, server_start_time, init_task
+
     logger.info("Starting ALF Diarization Server...")
     server_start_time = datetime.now().timestamp()
-    
+
     try:
         # Initialize communication protocol
         json_protocol = JsonProtocol()
         logger.info("JSON protocol initialized")
-        
+
         # Initialize RTTM handler
         rttm_handler = RTTMHandler()
         logger.info("RTTM handler initialized")
-        
-        # Initialize diarization pipeline
+
+        # Initialize diarization pipeline in background
         diarization_pipeline = DiarizationPipeline()
-        await diarization_pipeline.initialize()
-        logger.info("Diarization pipeline initialized")
-        
+        init_task = asyncio.create_task(diarization_pipeline.initialize())
+        logger.info("Diarization pipeline initialization started")
+
         logger.info("Diarization server startup completed")
-        
+
     except Exception as e:
         logger.error(f"Server startup failed: {e}")
         sys.exit(1)
@@ -122,7 +124,10 @@ async def startup_event():
 async def shutdown_event():
     """Clean up resources on shutdown."""
     logger.info("Shutting down ALF Diarization Server...")
-    
+
+    if init_task and not init_task.done():
+        await init_task
+
     if diarization_pipeline:
         await diarization_pipeline.cleanup()
     
@@ -137,9 +142,12 @@ async def health_check():
         HealthResponse: Server health status
     """
     uptime = datetime.now().timestamp() - server_start_time
-    
+    status = "initializing"
+    if diarization_pipeline and getattr(diarization_pipeline, "is_initialized", False):
+        status = "healthy"
+
     return HealthResponse(
-        status="healthy",
+        status=status,
         service="diarization",
         version="0.2.0",
         uptime_seconds=uptime
@@ -162,7 +170,11 @@ async def process_diarization(
     """
     if not diarization_pipeline:
         raise HTTPException(status_code=503, detail="Diarization pipeline not initialized")
-    
+
+    if not diarization_pipeline.is_initialized and init_task:
+        logger.info("Waiting for diarization pipeline to finish initialization")
+        await init_task
+
     # Validate input file
     audio_path = Path(request.audio_file_path)
     if not audio_path.exists():
@@ -397,5 +409,5 @@ if __name__ == "__main__":
         host=host,
         port=port,
         reload=False,
-        log_level="info"
+        log_level="info",
     )

--- a/tests/test_server_environment.py
+++ b/tests/test_server_environment.py
@@ -52,3 +52,48 @@ def test_environment_created_on_start(tmp_path, server_type, venv_attr, setup_me
             assert sm.start_transcription_server()
 
         mock_setup_env.assert_called_once()
+
+
+def test_label_studio_environment_created_on_diarization_start(tmp_path):
+    sm = ServerManager()
+    sm.venv_dir = tmp_path / "venvs"
+    sm.diarization_venv = sm.venv_dir / "diarization"
+    sm.label_studio_venv = sm.venv_dir / "label_studio"
+
+    # Create dummy server script location
+    work_dir = tmp_path / "diarization"
+    work_dir.mkdir()
+    (work_dir / "server.py").write_text("print('hello')")
+    sm.configs[ServerType.DIARIZATION].working_directory = work_dir
+
+    mock_process = MagicMock()
+    mock_process.pid = 1234
+    mock_process.stdout = None
+    mock_process.stderr = None
+
+    dummy_script = work_dir / "server.py"
+
+    with patch.object(sm, "_setup_diarization_environment") as mock_setup_diar, \
+         patch.object(sm, "_setup_label_studio_environment") as mock_setup_ls, \
+         patch.object(sm, "_start_label_studio_server", return_value=True), \
+         patch.object(sm, "_ensure_runtime_dependencies"), \
+         patch.object(sm, "_start_health_monitor"), \
+         patch.object(sm, "_wait_for_server_startup", return_value=True), \
+         patch.object(sm, "_prepare_server_startup", return_value=("python", str(dummy_script))), \
+         patch("communication.server_manager.subprocess.Popen", return_value=mock_process):
+
+        def create_dummy_diar_env():
+            python_path = sm.diarization_venv / ("Scripts" if os.name == "nt" else "bin") / "python"
+            python_path.parent.mkdir(parents=True, exist_ok=True)
+            python_path.touch()
+
+        def create_dummy_ls_env():
+            python_path = sm.label_studio_venv / ("Scripts" if os.name == "nt" else "bin") / "python"
+            python_path.parent.mkdir(parents=True, exist_ok=True)
+            python_path.touch()
+
+        mock_setup_diar.side_effect = create_dummy_diar_env
+        mock_setup_ls.side_effect = create_dummy_ls_env
+
+        assert sm.start_diarization_server(with_label_studio=True)
+        mock_setup_ls.assert_called_once()

--- a/tests/test_server_startup_logging.py
+++ b/tests/test_server_startup_logging.py
@@ -1,0 +1,28 @@
+import sys
+import logging
+
+from communication.server_manager import ServerManager, ServerType
+
+def test_logs_subprocess_output_on_startup_failure(tmp_path, caplog, monkeypatch):
+    script = tmp_path / "fail.py"
+    script.write_text(
+        "import sys\nprint('stdout msg')\nprint('stderr msg', file=sys.stderr)\nsys.exit(1)\n"
+    )
+
+    sm = ServerManager()
+
+    def fake_prepare(self, server_type):
+        return sys.executable, str(script)
+
+    monkeypatch.setattr(ServerManager, "_prepare_server_startup", fake_prepare)
+    monkeypatch.setattr(ServerManager, "_wait_for_server_startup", lambda self, st, t: False)
+
+    sm.configs[ServerType.DIARIZATION].working_directory = tmp_path
+
+    with caplog.at_level(logging.ERROR):
+        assert sm._start_server(ServerType.DIARIZATION) is False
+
+    info = sm.get_server_info(ServerType.DIARIZATION)
+    assert info is not None and info.state.name == "ERROR"
+    assert "stdout msg" in info.error_message
+    assert "stderr msg" in info.error_message

--- a/ui/pipeline_controller.py
+++ b/ui/pipeline_controller.py
@@ -72,8 +72,11 @@ class PipelineController:
             # Ensure diarization server is running
             if not self.server_manager.is_diarization_running():
                 logger.info("Starting diarization server...")
-                if not self.server_manager.start_diarization_server():
-                    raise RuntimeError("Failed to start diarization server")
+                try:
+                    if not self.server_manager.start_diarization_server():
+                        raise RuntimeError("server unavailable")
+                except Exception:
+                    raise RuntimeError("server unavailable")
             
             # Create processing request
             job_id = self._generate_job_id("diarization")
@@ -130,8 +133,11 @@ class PipelineController:
             # Ensure transcription server is running
             if not self.server_manager.is_transcription_running():
                 logger.info("Starting transcription server...")
-                if not self.server_manager.start_transcription_server():
-                    raise RuntimeError("Failed to start transcription server")
+                try:
+                    if not self.server_manager.start_transcription_server():
+                        raise RuntimeError("server unavailable")
+                except Exception:
+                    raise RuntimeError("server unavailable")
             
             # Create processing request
             job_id = self._generate_job_id("transcription")
@@ -325,12 +331,16 @@ SPEAKER {audio_stem} 1 9.700 2.800 <NA> <NA> speaker_01 <NA> <NA>""".format(
         configured for speaker diarization annotation and verification.
         """
         try:
-            # Label Studio should be automatically running when diarization server starts
             diarization_url = "http://localhost:8080"
-            
+
+            # Ensure the Label Studio server is running
+            if not self.server_manager.is_server_running(ServerType.LABEL_STUDIO):
+                logger.info("Label Studio server not running, attempting startup")
+                if not self.server_manager.start_label_studio_server():
+                    raise RuntimeError("Label Studio server failed to start")
+
             logger.info(f"Opening diarization browser: {diarization_url}")
-            
-            # Check if we can reach the URL first
+
             import requests
             try:
                 response = requests.get(diarization_url, timeout=5)
@@ -338,15 +348,12 @@ SPEAKER {audio_stem} 1 9.700 2.800 <NA> <NA> speaker_01 <NA> <NA>""".format(
                     webbrowser.open(diarization_url)
                     logger.info("Label Studio diarization browser opened successfully")
                 else:
-                    # Label Studio not responding properly
                     logger.warning(f"Label Studio responded with status code: {response.status_code}")
-                    webbrowser.open(diarization_url)  # Try opening anyway
+                    webbrowser.open(diarization_url)
             except requests.RequestException as e:
-                # Label Studio not available, try opening anyway or show message
                 logger.warning(f"Cannot reach Label Studio at {diarization_url}: {e}")
-                logger.info("Attempting to open browser anyway - Label Studio may still be starting up")
                 webbrowser.open(diarization_url)
-                
+
         except Exception as e:
             logger.error(f"Failed to open diarization browser: {e}")
             raise RuntimeError(f"Cannot open diarization browser: {e}")


### PR DESCRIPTION
## Summary
- create standalone uv-managed virtual environment for Label Studio frontend
- launch Label Studio from its own environment and clean up both environments on shutdown
- cover Label Studio environment creation with new unit test
- start Label Studio independently of diarization backend and log subprocess output on failed startups
- gate the diarization browser behind a running Label Studio server
- test logging for failed server startup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a79e2c988333a3819b2ba301f95b