### PR TITLE
Add Tkinter utility for Label Studio environment management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi[standard]
 label-studio
 label-studio-ml
+numpy
 transformers
 torch
 requests

--- a/simplelabelstudio.py
+++ b/simplelabelstudio.py
@@ -1,0 +1,191 @@
+"""Simple Label Studio environment manager with Tkinter.
+
+This module provides a very small graphical user interface that lets a user
+create a temporary virtual environment for `label-studio` using the `uv`
+package manager.  The interface exposes four buttons:
+
+``Create``
+    Builds a temporary virtual environment, installs ``label-studio`` and
+    starts the web server.  Everything is done inside a directory created by
+    :mod:`tempfile` so that it can easily be cleaned up later.
+
+``Check``
+    Displays information about the paths being used and whether
+    ``label-studio`` appears to be installed correctly.
+
+``Stop``
+    Stops the running Label Studio server if it is active.
+
+``Delete``
+    Removes the virtual environment directory entirely.
+
+The goal of this file is educational: every function is heavily commented so
+that newcomers to Python can follow the logic and experiment.  Real projects
+would normally contain more robust error handling, but that would distract
+from the core ideas demonstrated here.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import tkinter as tk
+from tkinter import messagebox
+
+# ---------------------------------------------------------------------------
+# Global state used by the button callbacks.  In a larger application this
+# would likely be managed by a dedicated class, but globals keep the example
+# easy to understand.
+# ---------------------------------------------------------------------------
+
+# Path to the temporary virtual environment.  ``None`` means no environment has
+# been created yet.
+env_dir: str | None = None
+
+# Handle to the running Label Studio server process.  ``None`` means the server
+# is not currently running.
+server_process: subprocess.Popen | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+def create_env() -> None:
+    """Create a temporary virtual environment and install Label Studio.
+
+    The steps performed are:
+
+    1. Use :func:`tempfile.mkdtemp` to create a new, unique directory.
+    2. Invoke ``uv venv`` to build a virtual environment inside that directory.
+    3. Install the ``label-studio`` package using ``uv pip``.
+    4. Start the Label Studio web server and keep a handle to the process so we
+       can stop it later.
+
+    This function performs several external commands which are executed using
+    :func:`subprocess.run` and :class:`subprocess.Popen`.  These calls may raise
+    :class:`subprocess.CalledProcessError` if something goes wrong.
+    """
+
+    global env_dir, server_process
+
+    # Avoid creating multiple environments if the user clicks "Create" twice.
+    if env_dir is not None:
+        messagebox.showinfo("Environment", f"Environment already exists at {env_dir}")
+        return
+
+    # 1. Create the temporary directory.
+    env_dir = tempfile.mkdtemp(prefix="labelstudio-")
+
+    # 2. Create the virtual environment using ``uv``.  ``check=True`` ensures an
+    #    exception is raised if the command fails.
+    subprocess.run(["uv", "venv", env_dir], check=True)
+
+    # 3. Install the ``label-studio`` package inside the new environment.  The
+    #    ``cwd`` argument changes the working directory so that ``uv`` operates
+    #    on the freshly created environment.
+    subprocess.run(["uv", "pip", "install", "label-studio"], check=True, cwd=env_dir)
+
+    # 4. Start the Label Studio server.  The executable lives in the ``bin``
+    #    directory of the virtual environment.  ``Popen`` is used here instead
+    #    of ``run`` because we want the server to run in the background.
+    executable = os.path.join(env_dir, "bin", "label-studio")
+    server_process = subprocess.Popen([executable, "start"], cwd=env_dir)
+
+    messagebox.showinfo("Environment", f"Environment created in\n{env_dir}")
+
+
+def check_env() -> str:
+    """Return information about the current setup.
+
+    The function checks:
+
+    * The location of the ``uv`` command using :func:`shutil.which`.
+    * Whether a virtual environment has been created.
+    * Whether ``label-studio`` appears to be installed in that environment.
+
+    The resulting information is both returned and displayed in a message box
+    for convenience.
+    """
+
+    uv_path = shutil.which("uv")
+
+    # Determine if Label Studio is installed by asking the virtual environment
+    # Python to report the package version.  Any failure is interpreted as the
+    # package being missing.
+    ls_installed = False
+    if env_dir is not None:
+        python_path = os.path.join(env_dir, "bin", "python")
+        try:
+            subprocess.run(
+                [python_path, "-m", "label_studio", "--version"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            ls_installed = True
+        except subprocess.CalledProcessError:
+            ls_installed = False
+
+    info = (
+        f"uv executable: {uv_path}\n"
+        f"env dir: {env_dir}\n"
+        f"label-studio installed: {ls_installed}"
+    )
+
+    messagebox.showinfo("Environment", info)
+    return info
+
+
+def stop_server() -> None:
+    """Terminate the running Label Studio server, if any."""
+
+    global server_process
+
+    if server_process is not None:
+        server_process.terminate()
+        server_process = None
+        messagebox.showinfo("Environment", "Server stopped")
+
+
+def delete_env() -> None:
+    """Remove the temporary virtual environment entirely."""
+
+    global env_dir
+
+    # Ensure the server is not running while we delete its files.
+    stop_server()
+
+    if env_dir is not None:
+        shutil.rmtree(env_dir)
+        messagebox.showinfo("Environment", f"Deleted environment at\n{env_dir}")
+        env_dir = None
+
+
+# ---------------------------------------------------------------------------
+# Tkinter user interface
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Launch the graphical user interface."""
+
+    root = tk.Tk()
+    root.title("Simple Label Studio")
+
+    # Using ``threading.Thread`` for the create button prevents the UI from
+    # freezing while ``uv`` performs potentially long operations.
+    tk.Button(root, text="Create", command=lambda: threading.Thread(target=create_env).start()).pack(
+        fill=tk.X
+    )
+    tk.Button(root, text="Check", command=check_env).pack(fill=tk.X)
+    tk.Button(root, text="Stop", command=stop_server).pack(fill=tk.X)
+    tk.Button(root, text="Delete", command=delete_env).pack(fill=tk.X)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_server_environment.py
+++ b/tests/test_server_environment.py
@@ -40,8 +40,10 @@ def test_environment_created_on_start(tmp_path, server_type, venv_attr, setup_me
          patch.object(sm, "_prepare_server_startup", return_value=("python", str(dummy_script))), \
          patch("communication.server_manager.subprocess.Popen", return_value=mock_process):
 
-        def create_dummy_env():
-            python_path = getattr(sm, venv_attr) / ("Scripts" if os.name == "nt" else "bin") / "python"
+        def create_dummy_env(*args, **kwargs):
+            python_path = getattr(sm, venv_attr) / (
+                "Scripts" if os.name == "nt" else "bin"
+            ) / "python"
             python_path.parent.mkdir(parents=True, exist_ok=True)
             python_path.touch()
         mock_setup_env.side_effect = create_dummy_env

--- a/tests/test_simplelabelstudio.py
+++ b/tests/test_simplelabelstudio.py
@@ -1,0 +1,79 @@
+import os
+from unittest import mock
+
+import simplelabelstudio as sls
+
+
+@mock.patch("simplelabelstudio.messagebox.showinfo")
+@mock.patch("simplelabelstudio.subprocess.Popen")
+@mock.patch("simplelabelstudio.subprocess.run")
+def test_create_env(mock_run, mock_popen, mock_info, tmp_path, monkeypatch):
+    """Creating an environment should invoke uv commands and start server."""
+    # Ensure a predictable directory is used
+    monkeypatch.setattr(sls.tempfile, "mkdtemp", lambda prefix: str(tmp_path))
+
+    sls.env_dir = None
+    sls.server_process = None
+
+    sls.create_env()
+
+    # The environment directory should be recorded
+    assert sls.env_dir == str(tmp_path)
+
+    # uv venv and uv pip install should be called
+    expected = [
+        mock.call(["uv", "venv", str(tmp_path)], check=True),
+        mock.call(["uv", "pip", "install", "label-studio"], check=True, cwd=str(tmp_path)),
+    ]
+    assert mock_run.call_args_list[:2] == expected
+
+    # Server process should be started
+    mock_popen.assert_called_once()
+
+
+@mock.patch("simplelabelstudio.messagebox.showinfo")
+@mock.patch("simplelabelstudio.subprocess.run")
+@mock.patch("simplelabelstudio.shutil.which", return_value="/usr/bin/uv")
+def test_check_env(mock_which, mock_run, mock_info, tmp_path, monkeypatch):
+    """Check should report uv path and installation status."""
+    # Pretend an environment exists
+    sls.env_dir = str(tmp_path)
+    python_exe = os.path.join(str(tmp_path), "bin", "python")
+
+    # Simulate successful check of label-studio
+    mock_run.return_value = mock.Mock()
+
+    result = sls.check_env()
+
+    assert "/usr/bin/uv" in result
+    assert f"env dir: {tmp_path}" in result
+    assert "label-studio installed: True" in result
+
+    # Ensure subprocess.run was called with the expected python executable
+    mock_run.assert_called_with(
+        [python_exe, "-m", "label_studio", "--version"],
+        check=True,
+        stdout=mock.ANY,
+        stderr=mock.ANY,
+    )
+
+
+@mock.patch("simplelabelstudio.messagebox.showinfo")
+def test_stop_and_delete(mock_info, tmp_path, monkeypatch):
+    """Stopping and deleting should clean up resources."""
+    # Set up fake environment and running process
+    sls.env_dir = str(tmp_path)
+    fake_process = mock.Mock()
+    sls.server_process = fake_process
+
+    # Patch rmtree so no real deletion happens
+    with mock.patch("simplelabelstudio.shutil.rmtree") as mock_rm:
+        sls.delete_env()
+
+    # Process should be terminated
+    fake_process.terminate.assert_called_once()
+
+    # Environment should be removed
+    mock_rm.assert_called_with(str(tmp_path))
+    assert sls.env_dir is None
+    assert sls.server_process is None


### PR DESCRIPTION
## Summary
- create simplelabelstudio.py – a heavily commented Tkinter UI to create, check, stop and delete a Label Studio virtual environment via `uv`
- add numpy to requirements to avoid missing-module errors
- adjust server environment test mock to accept arguments, allowing full test suite to pass

## Testing
- `pytest tests/test_simplelabelstudio.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c322c4efd08333b7acea505f675f92